### PR TITLE
skip index workspace if root uri is nil

### DIFF
--- a/server/internal/lsp/handlers/Initialize.go
+++ b/server/internal/lsp/handlers/Initialize.go
@@ -46,8 +46,11 @@ func (h *Handlers) Initialize(serverName string, serverVersion string, capabilit
 			},
 		},
 	}
-	h.state.SetProjectRootURI(*params.RootURI)
-	h.indexWorkspace()
+
+	if params.RootURI != nil {
+		h.state.SetProjectRootURI(*params.RootURI)
+		h.indexWorkspace()
+	}
 
 	return protocol.InitializeResult{
 		Capabilities: capabilities,


### PR DESCRIPTION
Fixes:

```bash
goroutine 36 [running]:
github.com/pherrymason/c3-lsp/internal/lsp/handlers.(*Handlers).Initialize(_, {_, _}, {_, _}, {{0x10a8bd640, 0x14000912fc0}, 0x140007fd3c0, {0x10a8562c0, 0x10ac42848}, ...}, ...)
	/Users/nikita/projects/c3-lsp/server/internal/lsp/handlers/Initialize.go:53 +0x7ac
github.com/pherrymason/c3-lsp/internal/lsp.NewServer.func2(0x140002d5c70, 0x14000166510)
	/Users/nikita/projects/c3-lsp/server/internal/lsp/server.go:89 +0xe8
github.com/tliron/glsp/protocol_3_16.(*Handler).Handle(0x1400014e800, 0x140002d5c70)
	/Users/nikita/go/pkg/mod/github.com/tliron/glsp@v0.2.3-0.20240511204206-c63625272e79/protocol_3_16/handler.go:126 +0x980
github.com/tliron/glsp/server.(*Server).handle(0x1400007e8a0, {0x10a8f4848, 0x14000190000}, 0x14000166000, 0x140000a01e0)
	/Users/nikita/go/pkg/mod/github.com/tliron/glsp@v0.2.3-0.20240511204206-c63625272e79/server/handler.go:47 +0x41c
github.com/sourcegraph/jsonrpc2.(*HandlerWithErrorConfigurer).Handle(0x140007f1870, {0x10a8f4848, 0x14000190000}, 0x14000166000, 0x140000a01e0)
	/Users/nikita/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/handler_with_error.go:21 +0x60
github.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0x14000166000, {0x10a8f4848, 0x14000190000})
	/Users/nikita/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/conn.go:205 +0x53c
created by github.com/sourcegraph/jsonrpc2.NewConn in goroutine 1
	/Users/nikita/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/conn.go:62 +0x344
[Error - 21:30:53] Server process exited with code 2.
```

Steps to reproduce:
Open VS Code without workspaces and create new untitled c3 file