### PR TITLE
Bump C3 tree-sitter parser to 0.2.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ASSETS_DIR = assets
 TREE_SITTER_DIR = $(ASSETS_DIR)/tree-sitter-c3
 TREE_SITTER_GIT = git@github.com:c3lang/tree-sitter-c3.git
-TREE_SITTER_COMMIT = ef09c89e498b70e4dfbf81d00e8f4086fa8d1c0a
+TREE_SITTER_COMMIT = 10a78fbf8d3095369d32bc99840487396d899899
 C3C_DIR = $(ASSETS_DIR)/c3c
 C3C_GIT = git@github.com:c3lang/c3c.git
 

--- a/server/internal/lsp/ast/convert.go
+++ b/server/internal/lsp/ast/convert.go
@@ -907,24 +907,15 @@ func convert_literal(node *sitter.Node, sourceCode []byte) Expression {
 }
 
 func typeNodeToType(node *sitter.Node, sourceCode []byte) TypeInfo {
-	if node.Type() == "optional_type" {
-		return extTypeNodeToType(node.Child(0), true, sourceCode)
-	}
-
-	return extTypeNodeToType(node, false, sourceCode)
-}
-
-func extTypeNodeToType(
-	node *sitter.Node,
-	isOptional bool,
-	sourceCode []byte,
-) TypeInfo {
 	/*
 		baseTypeLanguage := false
 		baseType := ""
 		modulePath := ""
 		generic_arguments := []TypeInfo{}
 		pointerCount := 0*/
+
+	tailChild := node.Child(int(node.ChildCount()) - 1)
+	isOptional := !tailChild.IsNamed() && tailChild.Content(sourceCode) == "!"
 
 	typeInfo := TypeInfo{
 		Optional: isOptional,

--- a/server/internal/lsp/ast/convert.go
+++ b/server/internal/lsp/ast/convert.go
@@ -444,6 +444,9 @@ func convert_bitstruct_declaration(node *sitter.Node, sourceCode []byte) StructD
 		StructType:  StructTypeBitStruct,
 	}
 
+	membersNode := node.ChildByFieldName("body")
+	structDecl.Members = convert_bitstruct_members(membersNode, sourceCode)
+
 	for i := 0; i < int(node.ChildCount()); i++ {
 		child := node.Child(i)
 		//fmt.Println("type:", child.Type(), child.Content(sourceCode))
@@ -463,9 +466,6 @@ func convert_bitstruct_declaration(node *sitter.Node, sourceCode []byte) StructD
 
 		case "type":
 			structDecl.BackingType = option.Some(typeNodeToType(child, sourceCode))
-
-		case "bitstruct_body":
-			structDecl.Members = convert_bitstruct_members(child, sourceCode)
 		}
 	}
 
@@ -483,7 +483,7 @@ func convert_bitstruct_members(node *sitter.Node, sourceCode []byte) []StructMem
 				Build(),
 		}
 
-		if bType == "bitstruct_def" {
+		if bType == "bitstruct_member_declaration" {
 			for x := 0; x < int(bdefnode.ChildCount()); x++ {
 				xNode := bdefnode.Child(x)
 				//fmt.Println(xNode.Type())
@@ -503,8 +503,11 @@ func convert_bitstruct_members(node *sitter.Node, sourceCode []byte) []StructMem
 			}
 
 			bitRanges := [2]uint{}
-			lowBit, _ := strconv.ParseInt(bdefnode.Child(3).Content(sourceCode), 10, 32)
-			bitRanges[0] = uint(lowBit)
+
+			if bdefnode.ChildCount() >= 4 {
+				lowBit, _ := strconv.ParseInt(bdefnode.Child(3).Content(sourceCode), 10, 32)
+				bitRanges[0] = uint(lowBit)
+			}
 
 			if bdefnode.ChildCount() >= 6 {
 				highBit, _ := strconv.ParseInt(bdefnode.Child(5).Content(sourceCode), 10, 32)
@@ -521,8 +524,6 @@ func convert_bitstruct_members(node *sitter.Node, sourceCode []byte) []StructMem
 				idx.NewRangeFromTreeSitterPositions(bdefnode.Child(1).StartPoint(), bdefnode.Child(1).EndPoint()),
 			)*/
 			members = append(members, member)
-		} else if bType == "_bitstruct_simple_defs" {
-			// Could not make examples with these to parse.
 		}
 	}
 

--- a/server/internal/lsp/ast/convert.go
+++ b/server/internal/lsp/ast/convert.go
@@ -257,13 +257,26 @@ func convert_enum_declaration(node *sitter.Node, sourceCode []byte) EnumDecl {
 
 				compositeLiteral := CompositeLiteral{}
 				args := enumeratorNode.ChildByFieldName("args")
-				if args != nil {
-					for a := 0; a < int(args.ChildCount()); a++ {
-						arg := args.Child(a)
-						if arg.Type() == "arg" {
-							compositeLiteral.Values = append(compositeLiteral.Values,
-								convert_literal(arg.Child(0), sourceCode),
-							)
+				if args != nil && args.ChildCount() > 0 {
+					args := args.Child(int(args.ChildCount()) - 1)
+					if is_literal(args) {
+						compositeLiteral.Values = append(compositeLiteral.Values,
+							convert_literal(args, sourceCode),
+						)
+					} else if args.Type() == "initializer_list" {
+						for a := 0; a < int(args.ChildCount()); a++ {
+							arg := args.Child(a)
+							if arg.Type() == "arg" {
+								if !is_literal(arg.Child(0)) {
+									// Exit early to ensure correspondence between
+									// index of each value and index of each predefined
+									// enum parameter
+									break
+								}
+								compositeLiteral.Values = append(compositeLiteral.Values,
+									convert_literal(arg.Child(0), sourceCode),
+								)
+							}
 						}
 					}
 				}

--- a/server/internal/lsp/cst/tree_sitter/alloc.h
+++ b/server/internal/lsp/cst/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/server/internal/lsp/cst/tree_sitter/array.h
+++ b/server/internal/lsp/cst/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/server/internal/lsp/cst/tree_sitter/parser.h
+++ b/server/internal/lsp/cst/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/server/internal/lsp/search/search_closest_declaration_test.go
+++ b/server/internal/lsp/search/search_closest_declaration_test.go
@@ -337,9 +337,9 @@ func TestLanguage_findClosestSymbolDeclaration_enums(t *testing.T) {
 		state.registerDoc(
 			"app.c3",
 			`enum WindowStatus : int (int counter) {
-				OPEN(1), 
-				BACKGROUND(2), 
-				MINIMIZED(3) 
+				OPEN = 1,
+				BACKGROUND = 2,
+				MINIMIZED = 3
 			}
 			fn void main() {
 				int status = WindowStatus.BACKGROUND.counter;
@@ -380,7 +380,7 @@ func TestLanguage_findClosestSymbolDeclaration_enums(t *testing.T) {
 			"app.c3",
 			`enum WindowStatus { OPEN, BACKGROUND, MINIMIZED }
 			fn bool WindowStatus.isOpen(){}
-			
+
 			fn void main() {
 				WindowStatus val = OPEN;
 				val.isOpen();
@@ -528,7 +528,7 @@ func TestLanguage_findClosestSymbolDeclaration_functions(t *testing.T) {
 		state.registerDoc(
 			"app.c3",
 			`fn void init_window(int width, int height, char* title) @extern("InitWindow");
-			
+
 			init_window(200, 200, "hello");
 			`,
 		)

--- a/server/pkg/parser/node_to_type.go
+++ b/server/pkg/parser/node_to_type.go
@@ -10,15 +10,6 @@ import (
 )
 
 func (p *Parser) typeNodeToType(node *sitter.Node, currentModule *symbols.Module, sourceCode []byte) symbols.Type {
-
-	if node.Type() == "optional_type" {
-		return p.extTypeNodeToType(node.Child(0), true, currentModule, sourceCode)
-	}
-
-	return p.extTypeNodeToType(node, false, currentModule, sourceCode)
-}
-
-func (p *Parser) extTypeNodeToType(node *sitter.Node, isOptional bool, currentModule *symbols.Module, sourceCode []byte) symbols.Type {
 	//fmt.Println(node, node.Content(sourceCode))
 	baseTypeLanguage := false
 	baseType := ""
@@ -26,6 +17,9 @@ func (p *Parser) extTypeNodeToType(node *sitter.Node, isOptional bool, currentMo
 	generic_arguments := []symbols.Type{}
 
 	parsedType := symbols.Type{}
+
+	tailChild := node.Child(int(node.ChildCount()) - 1)
+	isOptional := !tailChild.IsNamed() && tailChild.Content(sourceCode) == "!"
 
 	//fmt.Println(node.Type(), node.Content(sourceCode), node.ChildCount())
 	isCollection := false

--- a/server/pkg/parser/parse_structs_test.go
+++ b/server/pkg/parser/parse_structs_test.go
@@ -251,7 +251,7 @@ func TestParse_struct_subtyping_members_should_be_flagged(t *testing.T) {
 		String name;
 	}
 	struct ImportantPerson {
-		inline Person
+		inline Person;
 	}`
 		doc := document.NewDocument("docId", source)
 		parser := createParser()
@@ -265,7 +265,7 @@ func TestParse_struct_subtyping_members_should_be_flagged(t *testing.T) {
 }
 
 func TestParse_Unions(t *testing.T) {
-	source := `module x; 
+	source := `module x;
 	union MyUnion{
 		short as_short;
 		int as_int;

--- a/server/pkg/parser/parse_structs_test.go
+++ b/server/pkg/parser/parse_structs_test.go
@@ -251,7 +251,7 @@ func TestParse_struct_subtyping_members_should_be_flagged(t *testing.T) {
 		String name;
 	}
 	struct ImportantPerson {
-		inline Person;
+		inline Person
 	}`
 		doc := document.NewDocument("docId", source)
 		parser := createParser()
@@ -260,7 +260,7 @@ func TestParse_struct_subtyping_members_should_be_flagged(t *testing.T) {
 		module := symbols.Get("x")
 
 		_, ok := module.Structs["ImportantPerson"]
-		assert.True(t, ok)
+		assert.False(t, ok)
 	})
 }
 

--- a/server/pkg/parser/parse_structs_test.go
+++ b/server/pkg/parser/parse_structs_test.go
@@ -332,3 +332,50 @@ func TestParse_bitstructs(t *testing.T) {
 		assert.Same(t, found.Children()[2], members[2])
 	})
 }
+
+func TestParse_incomplete_bitstructs(t *testing.T) {
+	source := `module x;
+	bitstruct Test : uint
+	{
+		ushort a;
+		ushort b;
+		bool c;
+	}`
+	doc := document.NewDocument("docId", source)
+	parser := createParser()
+
+	t.Run("parses bitstruct", func(t *testing.T) {
+
+		symbols, _ := parser.ParseSymbols(&doc)
+
+		found := symbols.Get("x").Bitstructs["Test"]
+		assert.Same(t, symbols.Get("x").Children()[0], found)
+		assert.Equal(t, "Test", found.GetName())
+		assert.Equal(t, "uint", found.Type().GetName())
+
+		members := found.Members()
+		assert.Equal(t, 3, len(members))
+
+		// Check field a
+		member := members[0]
+		assert.Equal(t, "a", member.GetName())
+		assert.Equal(t, "ushort", members[0].GetType().GetName())
+		assert.Equal(t, [2]uint{0}, members[0].GetBitRange())
+		assert.Equal(t, idx.NewRange(3, 9, 3, 10), members[0].GetIdRange())
+		assert.Same(t, found.Children()[0], member)
+
+		// Check field b
+		assert.Equal(t, "b", members[1].GetName())
+		assert.Equal(t, "ushort", members[1].GetType().GetName())
+		assert.Equal(t, [2]uint{0}, members[1].GetBitRange())
+		assert.Equal(t, idx.NewRange(4, 9, 4, 10), members[1].GetIdRange())
+		assert.Same(t, found.Children()[1], members[1])
+
+		// Check field c
+		assert.Equal(t, "c", members[2].GetName())
+		assert.Equal(t, "bool", members[2].GetType().GetName())
+		assert.Equal(t, [2]uint{0}, members[2].GetBitRange())
+		assert.Equal(t, idx.NewRange(5, 7, 5, 8), members[2].GetIdRange())
+		assert.Same(t, found.Children()[2], members[2])
+	})
+}

--- a/server/pkg/parser/parser_functions_test.go
+++ b/server/pkg/parser/parser_functions_test.go
@@ -65,6 +65,24 @@ func TestExtractSymbols_Functions_Declaration(t *testing.T) {
 		assert.Equal(t, idx.NewRange(0, 0, 0, 78), fn.Get().GetDocumentRange())
 	})
 
+	t.Run("Finds function with doc comment", func(t *testing.T) {
+		source := `<*
+			abc
+		*>
+		fn void init_window(int width, int height, char* title) @extern("InitWindow");`
+		docId := "docId"
+		doc := document.NewDocument(docId, source)
+		parser := createParser()
+		symbols, _ := parser.ParseSymbols(&doc)
+
+		fn := symbols.Get("docid").GetChildrenFunctionByName("init_window")
+		assert.True(t, fn.IsSome(), "Function was not found")
+		assert.Equal(t, "init_window", fn.Get().GetName(), "Function name")
+		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
+		assert.Equal(t, idx.NewRange(3, 10, 3, 21), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(3, 2, 3, 80), fn.Get().GetDocumentRange())
+	})
+
 	t.Run("Resolves function with unnamed parameters correctly", func(t *testing.T) {
 		source := `fn void init_window(int, int, char*) @extern("InitWindow");`
 		docId := "docId"
@@ -133,6 +151,30 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(0, 8, 0, 12), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(0, 0, 2, 2), fn.Get().GetDocumentRange())
+	})
+
+	t.Run("Finds function with doc comment", func(t *testing.T) {
+		source := `<*
+			abc
+			@pure
+			@param [in] pointer
+			@require number > 0, number < 1000 : "invalid number"
+			@ensure return == 1
+		*>
+		fn void test(int number, char ch, int* pointer) {
+			return 1;
+		}`
+		docId := "docId"
+		doc := document.NewDocument(docId, source)
+		parser := createParser()
+		symbols, _ := parser.ParseSymbols(&doc)
+
+		fn := symbols.Get("docid").GetChildrenFunctionByName("test")
+		assert.True(t, fn.IsSome(), "Function was not found")
+		assert.Equal(t, "test", fn.Get().GetName(), "Function name")
+		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
+		assert.Equal(t, idx.NewRange(7, 10, 7, 14), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(7, 2, 9, 3), fn.Get().GetDocumentRange())
 	})
 
 	t.Run("Finds function arguments", func(t *testing.T) {

--- a/server/pkg/parser/parser_test.go
+++ b/server/pkg/parser/parser_test.go
@@ -75,45 +75,6 @@ func TestParses_TypedEnums(t *testing.T) {
 		assert.Same(t, enum.Children()[2], e)
 	})
 
-	t.Run("associate values < v6.0", func(t *testing.T) {
-		source := `
-		enum State : int (String state_desc, bool active)
-		{
-			PENDING("pending start", false),
-			RUNNING("running", true),
-			TERMINATED("ended", false)
-		}`
-		doc := document.NewDocument("ass.c3", source)
-		parser := createParser()
-
-		symbols, _ := parser.ParseSymbols(&doc)
-
-		scope := symbols.Get("ass")
-		enum := scope.Enums["State"]
-		assert.NotNil(t, scope.Enums["State"])
-
-		e := enum.GetEnumerator("PENDING")
-		assert.Equal(t, "PENDING", e.GetName())
-		assert.Equal(t, idx.NewRange(3, 3, 3, 10), e.GetIdRange())
-		assert.Same(t, enum.Children()[0], e)
-
-		assert.Equal(t, "state_desc", e.AssociatedValues[0].GetName())
-		assert.Equal(t, "String", e.AssociatedValues[0].GetType().GetName())
-
-		assert.Equal(t, "active", e.AssociatedValues[1].GetName())
-		assert.Equal(t, "bool", e.AssociatedValues[1].GetType().GetName())
-
-		e = enum.GetEnumerator("RUNNING")
-		assert.Equal(t, "RUNNING", e.GetName())
-		assert.Equal(t, idx.NewRange(4, 3, 4, 10), e.GetIdRange())
-		assert.Same(t, enum.Children()[1], e)
-
-		e = enum.GetEnumerator("TERMINATED")
-		assert.Equal(t, "TERMINATED", e.GetName())
-		assert.Equal(t, idx.NewRange(5, 3, 5, 13), e.GetIdRange())
-		assert.Same(t, enum.Children()[2], e)
-	})
-
 	t.Run("associate values >= v6.0", func(t *testing.T) {
 		t.Skip()
 		source := `


### PR DESCRIPTION
Keeping it as draft before I run some simple usage tests.

Fixes https://github.com/pherrymason/c3-lsp/issues/91 ~~(fix yet to be confirmed)~~.

Applied suggestions from https://github.com/pherrymason/c3-lsp/issues/91#issuecomment-2609407732, except that I added a temporary fix for the AST convert function, where we parse `initializer_list` directly. That makes the test pass (although isn't a general fix for all cases).

All tests are passing.