### PR TITLE
Greatly optimize type search

### DIFF
--- a/server/pkg/symbols/indexable.go
+++ b/server/pkg/symbols/indexable.go
@@ -37,6 +37,7 @@ type Indexable interface {
 	HasSourceCode() bool // This will return false for that code that is not accesible either because it belongs to the stdlib, or inside a .c3lib library. This results in disabling "Go to definition" / "Go to declaration" on these symbols
 
 	Children() []Indexable
+	ChildrenNames() []string
 	NestedScopes() []Indexable
 	ChildrenWithoutScopes() []Indexable
 	Insert(symbol Indexable)
@@ -60,31 +61,32 @@ type BaseIndexable struct {
 	Kind          protocol.CompletionItemKind
 	attributes    []string
 
-	children     []Indexable
-	nestedScopes []Indexable
+	children      []Indexable
+	childrenNames []string
+	nestedScopes  []Indexable
 }
 
-func (b BaseIndexable) GetName() string {
+func (b *BaseIndexable) GetName() string {
 	return b.name
 }
 
-func (b BaseIndexable) GetFQN() string {
+func (b *BaseIndexable) GetFQN() string {
 	return fmt.Sprintf("%s::%s", b.module.GetName(), b.GetName())
 }
 
-func (b BaseIndexable) GetKind() protocol.CompletionItemKind {
+func (b *BaseIndexable) GetKind() protocol.CompletionItemKind {
 	return b.Kind
 }
 
-func (b BaseIndexable) GetModuleString() string {
+func (b *BaseIndexable) GetModuleString() string {
 	return b.moduleString
 }
 
-func (b BaseIndexable) GetModule() ModulePath {
+func (b *BaseIndexable) GetModule() ModulePath {
 	return b.module
 }
 
-func (b BaseIndexable) IsSubModuleOf(module ModulePath) bool {
+func (b *BaseIndexable) IsSubModuleOf(module ModulePath) bool {
 	if module.IsEmpty() {
 		return false
 	}
@@ -92,23 +94,23 @@ func (b BaseIndexable) IsSubModuleOf(module ModulePath) bool {
 	return b.module.IsSubModuleOf(module)
 }
 
-func (b BaseIndexable) GetDocumentURI() string {
+func (b *BaseIndexable) GetDocumentURI() string {
 	return b.documentURI
 }
 
-func (b BaseIndexable) GetDocumentRange() Range {
+func (b *BaseIndexable) GetDocumentRange() Range {
 	return b.docRange
 }
 
-func (b BaseIndexable) GetIdRange() Range {
+func (b *BaseIndexable) GetIdRange() Range {
 	return b.idRange
 }
 
-func (b BaseIndexable) HasSourceCode() bool {
+func (b *BaseIndexable) HasSourceCode() bool {
 	return b.hasSourceCode
 }
 
-func (b BaseIndexable) IsPrivate() bool {
+func (b *BaseIndexable) IsPrivate() bool {
 	for _, attr := range b.attributes {
 		if attr == "@private" {
 			return true
@@ -129,27 +131,32 @@ func (b *BaseIndexable) SetAttributes(attributes []string) {
 	b.attributes = attributes
 }
 
-func (b BaseIndexable) Children() []Indexable {
+func (b *BaseIndexable) Children() []Indexable {
 	return b.children
 }
 
-func (b BaseIndexable) NestedScopes() []Indexable {
+func (b *BaseIndexable) ChildrenNames() []string {
+	return b.childrenNames
+}
+
+func (b *BaseIndexable) NestedScopes() []Indexable {
 	return b.nestedScopes
 }
 
-func (b BaseIndexable) ChildrenWithoutScopes() []Indexable {
+func (b *BaseIndexable) ChildrenWithoutScopes() []Indexable {
 	return b.children
 }
 
 func (b *BaseIndexable) Insert(child Indexable) {
 	b.children = append(b.children, child)
+	b.childrenNames = append(b.childrenNames, child.GetName())
 }
 
 func (b *BaseIndexable) InsertNestedScope(symbol Indexable) {
 	b.nestedScopes = append(b.nestedScopes, symbol)
 }
 
-func (b BaseIndexable) formatSource(source string) string {
+func (b *BaseIndexable) formatSource(source string) string {
 	return fmt.Sprintf("```c3\n%s```", source)
 }
 

--- a/server/pkg/symbols/module.go
+++ b/server/pkg/symbols/module.go
@@ -135,11 +135,11 @@ func (m *Module) SetGenericParameters(generics map[string]*GenericParameter) *Mo
 	return m
 }
 
-func (m Module) GetHoverInfo() string {
+func (m *Module) GetHoverInfo() string {
 	return m.name
 }
 
-func (m Module) GetChildrenFunctionByName(name string) option.Option[*Function] {
+func (m *Module) GetChildrenFunctionByName(name string) option.Option[*Function] {
 	for _, fun := range m.ChildrenFunctions {
 		if fun.GetFullName() == name {
 			return option.Some(fun)

--- a/server/pkg/symbols_table/symbols_table.go
+++ b/server/pkg/symbols_table/symbols_table.go
@@ -111,10 +111,17 @@ func (st *SymbolsTable) tryToSolveType(typeContext *PendingTypeContext, moduleNa
 }
 
 func (st *SymbolsTable) findTypeInModules(vType *symbols.Type) option.Option[string] {
+	vTypeName := vType.GetName()
 	for _, parsedModules := range st.parsedModulesByDocument {
-		for _, module := range parsedModules.Modules() {
-			for _, x := range module.Children() {
-				if x.GetName() == vType.GetName() {
+		// Use ModuleIds() to cheaply copy the slice of module names
+		// Using Modules() appears to lead to expensive clones
+		for _, moduleName := range parsedModules.ModuleIds() {
+			module := parsedModules.Get(moduleName)
+
+			// Use ChildrenNames() since we are only comparing names
+			// Avoid expensive cloning of children
+			for _, childName := range module.ChildrenNames() {
+				if childName == vTypeName {
 					// Found!
 					return option.Some(module.GetName())
 				}

--- a/server/pkg/symbols_table/unit_modules.go
+++ b/server/pkg/symbols_table/unit_modules.go
@@ -72,7 +72,7 @@ func (ps *UnitModules) RegisterModule(symbol *idx.Module) {
 	ps.modules.Set(symbol.GetModule().GetName(), symbol)
 }
 
-func (ps UnitModules) Get(moduleName string) *idx.Module {
+func (ps *UnitModules) Get(moduleName string) *idx.Module {
 	mod, ok := ps.modules.Get(moduleName)
 	if ok {
 		return mod


### PR DESCRIPTION
I had reported an apparently glaring performance issue with the LSP here: https://github.com/pherrymason/c3-lsp/pull/99#issuecomment-2610153848

It turns out this was due to an inefficiency while searching for types in module children: using `range` on maps returns a copy of its values, and it seems that this in combination with `.Modules()` caused entire modules to be cloned somehow (or something of the sort). I switched to `ModuleIds()`. In addition, I avoided cloning module children by just caching the names of module children. Thus, the issue seems to be fixed: CPU usage has gone down by 5-6x when triggering completions, and is now "normal", even in a project importing a large library such as `raylib.c3l`.

This could be made even more efficient by keeping a global map of type names to module pointers in the symbol table, but this should do for now.

Please consider giving it a quick spin locally first to confirm it's all right :)

## How I got here

To debug this, I added a CPU profiler to the LSP with the following diff, thanks to some sources found in a Google search:[^1][^2]

```diff
diff --git a/server/cmd/lsp/main.go b/server/cmd/lsp/main.go
index 87a1168774..2a926e99d6 100644
--- a/server/cmd/lsp/main.go
+++ b/server/cmd/lsp/main.go
@@ -1,10 +1,14 @@
 package main
 
+import _ "net/http/pprof" // CPU PROFILER
+
 import (
        "fmt"
        "log"
        "time"
 
+       "net/http" // CPU PROFILER
+
        "github.com/getsentry/sentry-go"
        "github.com/pherrymason/c3-lsp/internal/lsp/server"
 )
@@ -14,6 +18,12 @@
 const appName = "C3-LSP"
 
 func main() {
+       // ########### EXPOSE CPU PROFILER ###########
+       go func() {
+               log.Println(http.ListenAndServe("localhost:6060", nil))
+       }()
+        // ###########################################
+
        options, showHelp, showVersion := cmdLineArguments()
        commitHash := buildInfo()
        if showHelp {
```

And then, while the LSP was running, I executed, in my terminal,

```sh
curl -o analyze1.prof localhost:6060/debug/pprof/profile?seconds=20
```

and then proceeded to perform the operations which caused severe CPU usage and lag (triggering completions).

The saved file would then contain the information necessary to generate a flame graph of expensive function calls in the SpeedScope online app[^3], which I found in a blog post[^4]:

![image](https://github.com/user-attachments/assets/dce7931d-b6b1-4386-a1b9-e2d555c484a7)

After some research, I found a StackOverflow post[^5] which indicated that a repeated call to `runtime.duffcopy` indicates that a value is being copied many times, pointing to the usage of `range` in for loops. I proceeded to try to fiddle with the outermost for loop in the lowest function in the stack, but turns out that wasn't enough, leading me to create another flamegraph which pointed to the line iterating over `Modules()`  as the culprit, which eventually led me to replacing it with `ModuleIds()` with a simple `Get()` afterwards.

I also created `ChildrenNames()` as an additional optimization to avoid cloning module children unnecessarily. While Indexable types are usually pointers (and I forced `BaseIndexable` to be a pointer for its indexable implementation), some types, such as `Type` itself, don't appear to be.

After all this, I got the desired result of a fast and lean LSP. :rocket:

[^1]: "Profiling Go programs with pprof", by Julia Evans: https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/
[^2]: Official documentation for `net/http/pprof`, used to spin a webserver for generation of CPU profiles while a program is running: https://golang.org/pkg/net/http/pprof/
[^3]: SpeedScope visualizer: https://www.speedscope.app/
[^4]: "FlameGraphs for Code Optimization with Golang and SpeedScope", by Sathish Vj: https://sathishvj.medium.com/flamegraphs-for-code-optimization-with-golang-and-speedscope-80c20725fdd2
[^5]: "runtime.duffcopy is called a lot" - Stack Overflow: https://stackoverflow.com/questions/45786687/runtime-duffcopy-is-called-a-lot