### PR TITLE
Show documentation on hover and completion

### DIFF
--- a/server/internal/lsp/cst/parser.go
+++ b/server/internal/lsp/cst/parser.go
@@ -4,8 +4,9 @@ package cst
 //TSLanguage *tree_sitter_c3();
 import "C"
 import (
-	sitter "github.com/smacker/go-tree-sitter"
 	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
 )
 
 func NewSitterParser() *sitter.Parser {

--- a/server/internal/lsp/search/search_completion_list.go
+++ b/server/internal/lsp/search/search_completion_list.go
@@ -127,15 +127,18 @@ func extractExplicitModulePath(possibleModulePath string) option.Option[symbols.
 	return option.None[symbols.ModulePath]()
 }
 
-// TODO: Consider only returning the body text, not contracts here
-// Returns: nil | string
+// Obtains a doc comment's representation as markup, or nil.
+// Only the body is included (not contracts) for brevity.
+// Returns: nil | MarkupContent
 func GetCompletableDocComment(s symbols.Indexable) any {
 	docComment := s.GetDocComment()
 	if docComment == nil || docComment.GetBody() == "" {
 		return nil
 	} else {
-		// Don't include contract information in completion, for brevity
-		return docComment.GetBody()
+		return protocol.MarkupContent{
+			Kind:  protocol.MarkupKindMarkdown,
+			Value: docComment.GetBody(),
+		}
 	}
 }
 

--- a/server/internal/lsp/search/search_completion_list.go
+++ b/server/internal/lsp/search/search_completion_list.go
@@ -131,10 +131,11 @@ func extractExplicitModulePath(possibleModulePath string) option.Option[symbols.
 // Returns: nil | string
 func GetCompletableDocComment(s symbols.Indexable) any {
 	docComment := s.GetDocComment()
-	if docComment == "" {
+	if docComment == nil || docComment.GetBody() == "" {
 		return nil
 	} else {
-		return docComment
+		// Don't include contract information in completion, for brevity
+		return docComment.GetBody()
 	}
 }
 

--- a/server/internal/lsp/search/search_completion_list.go
+++ b/server/internal/lsp/search/search_completion_list.go
@@ -127,6 +127,17 @@ func extractExplicitModulePath(possibleModulePath string) option.Option[symbols.
 	return option.None[symbols.ModulePath]()
 }
 
+// TODO: Consider only returning the body text, not contracts here
+// Returns: nil | string
+func GetCompletableDocComment(s symbols.Indexable) any {
+	docComment := s.GetDocComment()
+	if docComment == "" {
+		return nil
+	} else {
+		return docComment
+	}
+}
+
 // Returns: []CompletionItem | CompletionList | nil
 func (s *Search) BuildCompletionList(
 	ctx context.CursorContext,
@@ -222,6 +233,9 @@ func (s *Search) BuildCompletionList(
 					items = append(items, protocol.CompletionItem{
 						Label: member.GetName(),
 						Kind:  &member.Kind,
+
+						// At this moment, struct members cannot receive documentation
+						Documentation: nil,
 					})
 				}
 			}
@@ -252,6 +266,7 @@ func (s *Search) BuildCompletionList(
 						NewText: fn.GetMethodName(),
 						Range:   replacementRange,
 					},
+					Documentation: GetCompletableDocComment(fn),
 				})
 			}
 
@@ -262,6 +277,9 @@ func (s *Search) BuildCompletionList(
 					items = append(items, protocol.CompletionItem{
 						Label: enumerator.GetName(),
 						Kind:  &enumerator.Kind,
+
+						// No documentation for enumerators at this time
+						Documentation: nil,
 					})
 				}
 			}
@@ -273,6 +291,9 @@ func (s *Search) BuildCompletionList(
 					items = append(items, protocol.CompletionItem{
 						Label: constant.GetName(),
 						Kind:  &constant.Kind,
+
+						// No documentation for fault constants at this time
+						Documentation: nil,
 					})
 				}
 			}
@@ -310,11 +331,13 @@ func (s *Search) BuildCompletionList(
 						NewText: storedIdentifier.GetName(),
 						Range:   editRange,
 					},
+					Documentation: GetCompletableDocComment(storedIdentifier),
 				})
 			} else {
 				items = append(items, protocol.CompletionItem{
-					Label: storedIdentifier.GetName(),
-					Kind:  cast.ToPtr(storedIdentifier.GetKind()),
+					Label:         storedIdentifier.GetName(),
+					Kind:          cast.ToPtr(storedIdentifier.GetKind()),
+					Documentation: GetCompletableDocComment(storedIdentifier),
 				})
 			}
 		}

--- a/server/internal/lsp/search/search_completion_list_test.go
+++ b/server/internal/lsp/search/search_completion_list_test.go
@@ -214,7 +214,7 @@ func TestBuildCompletionList_should_return_nil_when_cursor_is_in_literal(t *test
 	search := NewSearchWithoutLog()
 	state.registerDoc(
 		"test.c3",
-		`module foo; 
+		`module foo;
 		printf("main.");`,
 	)
 
@@ -340,15 +340,22 @@ func TestBuildCompletionList(t *testing.T) {
 	t.Run("Should suggest variable names defined in module", func(t *testing.T) {
 		source := `
 		int variable = 3;
-		int xanadu = 10;`
-		expectedKind := protocol.CompletionItemKindVariable
+		int xanadu = 10;
+		<* doc *>
+		int documented = 50;
+		<* const doc *>
+		const int MY_CONST = 100;`
+		expectedVarKind := protocol.CompletionItemKindVariable
+		expectedConstKind := protocol.CompletionItemKindConstant
 		cases := []struct {
 			input    string
 			expected protocol.CompletionItem
 		}{
-			{"v", protocol.CompletionItem{Label: "variable", Kind: &expectedKind}},
-			{"va", protocol.CompletionItem{Label: "variable", Kind: &expectedKind}},
-			{"x", protocol.CompletionItem{Label: "xanadu", Kind: &expectedKind}},
+			{"v", protocol.CompletionItem{Label: "variable", Kind: &expectedVarKind}},
+			{"va", protocol.CompletionItem{Label: "variable", Kind: &expectedVarKind}},
+			{"x", protocol.CompletionItem{Label: "xanadu", Kind: &expectedVarKind}},
+			{"docu", protocol.CompletionItem{Label: "documented", Kind: &expectedVarKind, Documentation: "doc"}},
+			{"MY_C", protocol.CompletionItem{Label: "MY_CONST", Kind: &expectedConstKind, Documentation: "const doc"}},
 		}
 
 		for n, tt := range cases {
@@ -358,7 +365,7 @@ func TestBuildCompletionList(t *testing.T) {
 					source+"\n"+tt.input,
 				)
 
-				position := buildPosition(4, 1) // Cursor after `v|`
+				position := buildPosition(8, 1) // Cursor after `v|`
 
 				completionList := search.BuildCompletionList(
 					context.CursorContext{
@@ -430,10 +437,10 @@ func TestBuildCompletionList(t *testing.T) {
 			expected []protocol.CompletionItem
 		}{
 			{"p", []protocol.CompletionItem{
-				{Label: "process", Kind: &expectedKind},
+				{Label: "process", Kind: &expectedKind, Documentation: nil},
 			}},
 			{"proc", []protocol.CompletionItem{
-				{Label: "process", Kind: &expectedKind},
+				{Label: "process", Kind: &expectedKind, Documentation: nil},
 			}},
 		}
 
@@ -457,6 +464,144 @@ func TestBuildCompletionList(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Should suggest function names with documentation", func(t *testing.T) {
+		sourceStart := `
+		<* abc *>
+		fn void process(){}
+		fn void main() {`
+		sourceEnd := `
+		}`
+
+		expectedKind := protocol.CompletionItemKindFunction
+		cases := []struct {
+			input    string
+			expected []protocol.CompletionItem
+		}{
+			{"p", []protocol.CompletionItem{
+				{Label: "process", Kind: &expectedKind, Documentation: "abc"},
+			}},
+			{"proc", []protocol.CompletionItem{
+				{Label: "process", Kind: &expectedKind, Documentation: "abc"},
+			}},
+		}
+
+		for n, tt := range cases {
+			t.Run(fmt.Sprintf("Case #%d", n), func(t *testing.T) {
+				state.registerDoc(
+					"test.c3",
+					sourceStart+"\n"+tt.input+"\n"+sourceEnd,
+				)
+				position := buildPosition(5, uint(len(tt.input))) // Cursor after `<input>|`
+
+				completionList := search.BuildCompletionList(
+					context.CursorContext{
+						Position: position,
+						DocURI:   "test.c3",
+					},
+					&state.state)
+
+				assert.Equal(t, len(tt.expected), len(completionList))
+				assert.Equal(t, tt.expected, completionList)
+			})
+		}
+	})
+
+	t.Run("Should suggest function names with contracts in documentation", func(t *testing.T) {
+		sourceStart := `
+		<*
+		abc
+
+		@param [in] a
+		@require a > 0, a < 1000 : "woah"
+		@ensure return > 1
+		*>
+		fn int process(int a){ return 5; }
+		fn void main() {`
+		sourceEnd := `
+		}`
+
+		expectedDoc := `abc
+@param [in] a
+@require a > 0, a < 1000 : "woah"
+@ensure return > 1`
+
+		expectedKind := protocol.CompletionItemKindFunction
+		cases := []struct {
+			input    string
+			expected []protocol.CompletionItem
+		}{
+			{"p", []protocol.CompletionItem{
+				{Label: "process", Kind: &expectedKind, Documentation: expectedDoc},
+			}},
+			{"proc", []protocol.CompletionItem{
+				{Label: "process", Kind: &expectedKind, Documentation: expectedDoc},
+			}},
+		}
+
+		for n, tt := range cases {
+			t.Run(fmt.Sprintf("Case #%d", n), func(t *testing.T) {
+				state.registerDoc(
+					"test.c3",
+					sourceStart+"\n"+tt.input+"\n"+sourceEnd,
+				)
+				position := buildPosition(11, uint(len(tt.input))) // Cursor after `<input>|`
+
+				completionList := search.BuildCompletionList(
+					context.CursorContext{
+						Position: position,
+						DocURI:   "test.c3",
+					},
+					&state.state)
+
+				assert.Equal(t, len(tt.expected), len(completionList))
+				assert.Equal(t, tt.expected, completionList)
+			})
+		}
+	})
+}
+
+func TestBuildCompletionList_struct_type(t *testing.T) {
+	commonlog.Configure(2, nil)
+	logger := commonlog.GetLogger("C3-LSP.parser")
+
+	source := `
+	struct Cough { int a; }
+	<* doc *>
+	struct Color { int r; int g; int b; }
+`
+	cases := []struct {
+		input    string
+		expected []protocol.CompletionItem
+	}{
+		{"Co", []protocol.CompletionItem{
+			CreateCompletionItemWithDoc("Color", protocol.CompletionItemKindStruct, "doc"),
+			CreateCompletionItem("Cough", protocol.CompletionItemKindStruct),
+		}},
+		{"Col", []protocol.CompletionItem{
+			CreateCompletionItemWithDoc("Color", protocol.CompletionItemKindStruct, "doc"),
+		}},
+	}
+
+	for n, tt := range cases {
+		t.Run(fmt.Sprintf("Case #%d", n), func(t *testing.T) {
+			state := NewTestState(logger)
+			state.registerDoc("test.c3", source+tt.input+`}`)
+
+			position := buildPosition(5, uint(len(tt.input))) // Cursor after `<input>|`
+
+			search := NewSearchWithoutLog()
+			completionList := search.BuildCompletionList(
+				context.CursorContext{
+					Position: position,
+					DocURI:   "test.c3",
+				},
+				&state.state)
+
+			assert.Equal(t, len(tt.expected), len(completionList))
+			assert.Equal(t, tt.expected, completionList)
+		})
+	}
 }
 
 func TestBuildCompletionList_struct_suggest_all_its_members(t *testing.T) {
@@ -466,12 +611,13 @@ func TestBuildCompletionList_struct_suggest_all_its_members(t *testing.T) {
 
 	source := `struct Color { int red; int green; int blue; }
 	struct Square { int width; int height; Color color; }
+	<* member doc *>
 	fn void Square.toCircle() {}
 	fn void main() {
 		Square inst;
 		inst.
 	}`
-	position := buildPosition(6, 7) // Cursor after `inst.|`
+	position := buildPosition(7, 7) // Cursor after `inst.|`
 
 	state := NewTestState(logger)
 	state.registerDoc("test.c3", source)
@@ -493,8 +639,9 @@ func TestBuildCompletionList_struct_suggest_all_its_members(t *testing.T) {
 			Kind:  cast.ToPtr(protocol.CompletionItemKindMethod),
 			TextEdit: protocol.TextEdit{
 				NewText: "toCircle",
-				Range:   protocol_utils.NewLSPRange(5, 7, 5, 8),
+				Range:   protocol_utils.NewLSPRange(6, 7, 6, 8),
 			},
+			Documentation: "member doc",
 		},
 		{Label: "width", Kind: &expectedKind},
 	}, completionList)
@@ -656,6 +803,7 @@ func TestBuildCompletionList_enums(t *testing.T) {
 	t.Run("Should suggest Enum type", func(t *testing.T) {
 		source := `
 		enum Cough { COH, COUGH, COUGHCOUGH}
+		<* doc *>
 		enum Color { RED, GREEN, BLUE }
 `
 		cases := []struct {
@@ -663,11 +811,11 @@ func TestBuildCompletionList_enums(t *testing.T) {
 			expected []protocol.CompletionItem
 		}{
 			{"Co", []protocol.CompletionItem{
-				CreateCompletionItem("Color", protocol.CompletionItemKindEnum),
+				CreateCompletionItemWithDoc("Color", protocol.CompletionItemKindEnum, "doc"),
 				CreateCompletionItem("Cough", protocol.CompletionItemKindEnum),
 			}},
 			{"Col", []protocol.CompletionItem{
-				CreateCompletionItem("Color", protocol.CompletionItemKindEnum),
+				CreateCompletionItemWithDoc("Color", protocol.CompletionItemKindEnum, "doc"),
 			}},
 		}
 
@@ -676,7 +824,7 @@ func TestBuildCompletionList_enums(t *testing.T) {
 				state := NewTestState(logger)
 				state.registerDoc("test.c3", source+tt.input+`}`)
 
-				position := buildPosition(4, uint(len(tt.input))) // Cursor after `<input>|`
+				position := buildPosition(5, uint(len(tt.input))) // Cursor after `<input>|`
 
 				search := NewSearchWithoutLog()
 				completionList := search.BuildCompletionList(
@@ -756,6 +904,7 @@ func TestBuildCompletionList_faults(t *testing.T) {
 	t.Run("Should suggest Fault type", func(t *testing.T) {
 		source := `
 		fault WindowError { COH, COUGH, COUGHCOUGH}
+		<* doc *>
 		fault WindowFileError { NOT_FOUND, NO_PERMISSIONS }
 `
 		cases := []struct {
@@ -764,10 +913,10 @@ func TestBuildCompletionList_faults(t *testing.T) {
 		}{
 			{"Wind", []protocol.CompletionItem{
 				CreateCompletionItem("WindowError", protocol.CompletionItemKindEnum),
-				CreateCompletionItem("WindowFileError", protocol.CompletionItemKindEnum),
+				CreateCompletionItemWithDoc("WindowFileError", protocol.CompletionItemKindEnum, "doc"),
 			}},
 			{"WindowFile", []protocol.CompletionItem{
-				CreateCompletionItem("WindowFileError", protocol.CompletionItemKindEnum),
+				CreateCompletionItemWithDoc("WindowFileError", protocol.CompletionItemKindEnum, "doc"),
 			}},
 		}
 
@@ -775,7 +924,7 @@ func TestBuildCompletionList_faults(t *testing.T) {
 			t.Run(fmt.Sprintf("Case #%d", n), func(t *testing.T) {
 				state := NewTestState()
 				state.registerDoc("test.c3", source+tt.input+`}`)
-				position := buildPosition(4, uint(len(tt.input))) // Cursor after `<input>|`
+				position := buildPosition(5, uint(len(tt.input))) // Cursor after `<input>|`
 
 				search := NewSearchWithoutLog()
 				completionList := search.BuildCompletionList(
@@ -863,11 +1012,12 @@ func TestBuildCompletionList_modules(t *testing.T) {
 		}{
 			{
 				`
+				<* doc *>
 				module app;
 				int version = 1;
 				a
 				`,
-				buildPosition(4, 5), // Cursor at `a|`
+				buildPosition(5, 5), // Cursor at `a|`
 				[]protocol.CompletionItem{{
 					Label:  "app",
 					Kind:   cast.ToPtr(protocol.CompletionItemKindModule),
@@ -876,6 +1026,7 @@ func TestBuildCompletionList_modules(t *testing.T) {
 						NewText: "app",
 						Range:   protocol_utils.NewLSPRange(3, 4, 3, 5),
 					},
+					Documentation: "doc",
 				},
 				},
 				true,
@@ -988,7 +1139,7 @@ func TestBuildCompletionList_modules(t *testing.T) {
 				module app;
 				int version = 1;
 				module app::foo;
-				
+
 				app::`,
 				buildPosition(6, 9), // Cursor at `a|`
 				[]protocol.CompletionItem{
@@ -1059,7 +1210,9 @@ func TestBuildCompletionList_interfaces(t *testing.T) {
 		state := NewTestState()
 		state.registerDoc(
 			"app.c3",
-			`interface EmulatorConsole
+			`
+		<* doc *>
+		interface EmulatorConsole
 		{
 			fn void run();
 		}
@@ -1068,7 +1221,7 @@ func TestBuildCompletionList_interfaces(t *testing.T) {
 		search := NewSearchWithoutLog()
 		completionList := search.BuildCompletionList(
 			context.CursorContext{
-				Position: buildPosition(5, 18),
+				Position: buildPosition(7, 18),
 				DocURI:   "app.c3",
 			},
 			&state.state)
@@ -1078,8 +1231,9 @@ func TestBuildCompletionList_interfaces(t *testing.T) {
 			t,
 			[]protocol.CompletionItem{
 				{
-					Label: "EmulatorConsole",
-					Kind:  cast.ToPtr(protocol.CompletionItemKindInterface),
+					Label:         "EmulatorConsole",
+					Kind:          cast.ToPtr(protocol.CompletionItemKindInterface),
+					Documentation: "doc",
 				},
 			},
 			completionList,
@@ -1088,7 +1242,11 @@ func TestBuildCompletionList_interfaces(t *testing.T) {
 }
 
 func CreateCompletionItem(label string, kind protocol.CompletionItemKind) protocol.CompletionItem {
-	return protocol.CompletionItem{Label: label, Kind: &kind}
+	return protocol.CompletionItem{Label: label, Kind: &kind, Documentation: nil}
+}
+
+func CreateCompletionItemWithDoc(label string, kind protocol.CompletionItemKind, doc string) protocol.CompletionItem {
+	return protocol.CompletionItem{Label: label, Kind: &kind, Documentation: doc}
 }
 
 func TestBuildCompletionList_should_resolve_(t *testing.T) {

--- a/server/internal/lsp/search/search_completion_list_test.go
+++ b/server/internal/lsp/search/search_completion_list_test.go
@@ -521,10 +521,8 @@ func TestBuildCompletionList(t *testing.T) {
 		sourceEnd := `
 		}`
 
-		expectedDoc := `abc
-@param [in] a
-@require a > 0, a < 1000 : "woah"
-@ensure return > 1`
+		// Contracts are excluded
+		expectedDoc := "abc"
 
 		expectedKind := protocol.CompletionItemKindFunction
 		cases := []struct {

--- a/server/internal/lsp/search/search_completion_list_test.go
+++ b/server/internal/lsp/search/search_completion_list_test.go
@@ -27,6 +27,13 @@ func filterOutKeywordSuggestions(completionList []protocol.CompletionItem) []pro
 	return filteredCompletionList
 }
 
+func asMarkdown(text string) protocol.MarkupContent {
+	return protocol.MarkupContent{
+		Kind:  protocol.MarkupKindMarkdown,
+		Value: text,
+	}
+}
+
 func Test_isCompletingAChain(t *testing.T) {
 	cases := []struct {
 		name                     string
@@ -354,8 +361,8 @@ func TestBuildCompletionList(t *testing.T) {
 			{"v", protocol.CompletionItem{Label: "variable", Kind: &expectedVarKind}},
 			{"va", protocol.CompletionItem{Label: "variable", Kind: &expectedVarKind}},
 			{"x", protocol.CompletionItem{Label: "xanadu", Kind: &expectedVarKind}},
-			{"docu", protocol.CompletionItem{Label: "documented", Kind: &expectedVarKind, Documentation: "doc"}},
-			{"MY_C", protocol.CompletionItem{Label: "MY_CONST", Kind: &expectedConstKind, Documentation: "const doc"}},
+			{"docu", protocol.CompletionItem{Label: "documented", Kind: &expectedVarKind, Documentation: asMarkdown("doc")}},
+			{"MY_C", protocol.CompletionItem{Label: "MY_CONST", Kind: &expectedConstKind, Documentation: asMarkdown("const doc")}},
 		}
 
 		for n, tt := range cases {
@@ -479,10 +486,10 @@ func TestBuildCompletionList(t *testing.T) {
 			expected []protocol.CompletionItem
 		}{
 			{"p", []protocol.CompletionItem{
-				{Label: "process", Kind: &expectedKind, Documentation: "abc"},
+				{Label: "process", Kind: &expectedKind, Documentation: asMarkdown("abc")},
 			}},
 			{"proc", []protocol.CompletionItem{
-				{Label: "process", Kind: &expectedKind, Documentation: "abc"},
+				{Label: "process", Kind: &expectedKind, Documentation: asMarkdown("abc")},
 			}},
 		}
 
@@ -522,7 +529,7 @@ func TestBuildCompletionList(t *testing.T) {
 		}`
 
 		// Contracts are excluded
-		expectedDoc := "abc"
+		expectedDoc := asMarkdown("abc")
 
 		expectedKind := protocol.CompletionItemKindFunction
 		cases := []struct {
@@ -639,7 +646,7 @@ func TestBuildCompletionList_struct_suggest_all_its_members(t *testing.T) {
 				NewText: "toCircle",
 				Range:   protocol_utils.NewLSPRange(6, 7, 6, 8),
 			},
-			Documentation: "member doc",
+			Documentation: asMarkdown("member doc"),
 		},
 		{Label: "width", Kind: &expectedKind},
 	}, completionList)
@@ -1024,7 +1031,7 @@ func TestBuildCompletionList_modules(t *testing.T) {
 						NewText: "app",
 						Range:   protocol_utils.NewLSPRange(3, 4, 3, 5),
 					},
-					Documentation: "doc",
+					Documentation: asMarkdown("doc"),
 				},
 				},
 				true,
@@ -1231,7 +1238,7 @@ func TestBuildCompletionList_interfaces(t *testing.T) {
 				{
 					Label:         "EmulatorConsole",
 					Kind:          cast.ToPtr(protocol.CompletionItemKindInterface),
-					Documentation: "doc",
+					Documentation: asMarkdown("doc"),
 				},
 			},
 			completionList,
@@ -1244,7 +1251,7 @@ func CreateCompletionItem(label string, kind protocol.CompletionItemKind) protoc
 }
 
 func CreateCompletionItemWithDoc(label string, kind protocol.CompletionItemKind, doc string) protocol.CompletionItem {
-	return protocol.CompletionItem{Label: label, Kind: &kind, Documentation: doc}
+	return protocol.CompletionItem{Label: label, Kind: &kind, Documentation: asMarkdown(doc)}
 }
 
 func TestBuildCompletionList_should_resolve_(t *testing.T) {

--- a/server/internal/lsp/server/TextDocumentHover.go
+++ b/server/internal/lsp/server/TextDocumentHover.go
@@ -22,8 +22,13 @@ func (h *Server) TextDocumentHover(context *glsp.Context, params *protocol.Hover
 
 	// expected behaviour:
 	// hovering on variables: display variable type + any description
-	// hovering on functions: display function signature
+	// hovering on functions: display function signature + docs
 	// hovering on members: same as variable
+
+	docComment := foundSymbol.GetDocComment()
+	if docComment != "" {
+		docComment = "\n\n" + docComment
+	}
 
 	extraLine := ""
 
@@ -45,7 +50,8 @@ func (h *Server) TextDocumentHover(context *glsp.Context, params *protocol.Hover
 			Value: "```c3" + "\n" +
 				sizeInfo +
 				foundSymbol.GetHoverInfo() + "\n```" +
-				extraLine,
+				extraLine +
+				docComment,
 		},
 	}
 

--- a/server/internal/lsp/server/TextDocumentHover.go
+++ b/server/internal/lsp/server/TextDocumentHover.go
@@ -25,9 +25,10 @@ func (h *Server) TextDocumentHover(context *glsp.Context, params *protocol.Hover
 	// hovering on functions: display function signature + docs
 	// hovering on members: same as variable
 
-	docComment := foundSymbol.GetDocComment()
-	if docComment != "" {
-		docComment = "\n\n" + docComment
+	docCommentData := foundSymbol.GetDocComment()
+	docComment := ""
+	if docCommentData != nil {
+		docComment = "\n\n" + docCommentData.DisplayBodyWithContracts()
 	}
 
 	extraLine := ""

--- a/server/internal/lsp/server/TextDocumentSignatureHelp.go
+++ b/server/internal/lsp/server/TextDocumentSignatureHelp.go
@@ -48,16 +48,29 @@ func (h *Server) TextDocumentSignatureHelp(context *glsp.Context, params *protoc
 			parameters,
 			protocol.ParameterInformation{
 				Label: arg.GetType().String() + " " + arg.GetName(),
+
+				// TODO: Parse '@param' contract text to get param docs
+				Documentation: nil,
 			},
 		)
 	}
 
 	// Count number of commas (,) written from previous `(`
 	activeParameter := countWrittenArguments(posOption.Get(), doc.SourceCode)
+
+	var docs any = nil
+	docComment := function.GetDocComment()
+	if docComment != nil {
+		docs = protocol.MarkupContent{
+			Kind:  protocol.MarkupKindMarkdown,
+			Value: docComment.DisplayBodyWithContracts(),
+		}
+	}
+
 	signature := protocol.SignatureInformation{
 		Label:         function.GetFQN() + "(" + strings.Join(argsToStringify, ", ") + ")",
 		Parameters:    parameters,
-		Documentation: "", // TODO: Parse comments on functions to include them here.
+		Documentation: docs,
 	}
 	if activeParameter.IsSome() {
 		arg := activeParameter.Get()

--- a/server/pkg/dedent/dedent.go
+++ b/server/pkg/dedent/dedent.go
@@ -1,0 +1,56 @@
+package dedent
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	whitespaceOnly    = regexp.MustCompile("(?m)^[ \t]+$")
+	leadingWhitespace = regexp.MustCompile("(?m)(^[ \t]*)(?:[^ \t\n])")
+)
+
+// Original code from https://github.com/lithammer/dedent
+// Includes a modified version of https://github.com/lithammer/dedent/pull/17 to support post-first-line indent.
+//
+// Dedent removes any common leading whitespace from every line in text.
+//
+// This can be used to make multiline strings to line up with the left edge of
+// the display, while still presenting them in the source code in indented
+// form.
+func Dedent(text string) string {
+	var margin string
+
+	text = whitespaceOnly.ReplaceAllString(text, "")
+	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
+
+	// Look for the longest leading string of spaces and tabs common to all
+	// lines, except first non-indented lines.
+	firstIndentedLine := 0
+	for i, indent := range indents {
+		if i == 0 && indent[1] == "" {
+			// no indent in first line, ignore it
+			firstIndentedLine = 1
+		} else if i == firstIndentedLine {
+			margin = indent[1]
+		} else if strings.HasPrefix(indent[1], margin) {
+			// Current line more deeply indented than previous winner:
+			// no change (previous winner is still on top).
+			continue
+		} else if strings.HasPrefix(margin, indent[1]) {
+			// Current line consistent with and no deeper than previous winner:
+			// it's the new winner.
+			margin = indent[1]
+		} else {
+			// Current line and previous winner have no common whitespace:
+			// there is no margin.
+			margin = ""
+			break
+		}
+	}
+
+	if margin != "" {
+		text = regexp.MustCompile("(?m)^"+margin).ReplaceAllString(text, "")
+	}
+	return text
+}

--- a/server/pkg/parser/node_to_doc_comment.go
+++ b/server/pkg/parser/node_to_doc_comment.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"github.com/pherrymason/c3-lsp/pkg/cast"
+	"github.com/pherrymason/c3-lsp/pkg/dedent"
 	idx "github.com/pherrymason/c3-lsp/pkg/symbols"
 	sitter "github.com/smacker/go-tree-sitter"
 )
@@ -35,7 +36,8 @@ func (p *Parser) nodeToDocComment(node *sitter.Node, sourceCode []byte) idx.DocC
 	body := ""
 	bodyNode := node.Child(1)
 	if bodyNode.Type() == "doc_comment_text" {
-		body = bodyNode.Content(sourceCode)
+		// Dedent to accept indented doc strings.
+		body = dedent.Dedent(bodyNode.Content(sourceCode))
 	}
 
 	docComment := idx.NewDocComment(body)
@@ -47,6 +49,9 @@ func (p *Parser) nodeToDocComment(node *sitter.Node, sourceCode []byte) idx.DocC
 				name := contractNode.ChildByFieldName("name").Content(sourceCode)
 				body := ""
 				if contractNode.ChildCount() >= 2 {
+					// Right now, contracts can only have a single line, so we don't dedent.
+					// They can also be arbitrary expressions, so it's best to not modify them
+					// at the moment.
 					body = contractNode.Child(1).Content(sourceCode)
 				}
 

--- a/server/pkg/parser/node_to_doc_comment.go
+++ b/server/pkg/parser/node_to_doc_comment.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"github.com/pherrymason/c3-lsp/pkg/cast"
+	idx "github.com/pherrymason/c3-lsp/pkg/symbols"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+/*
+// From grammar.js in tree-sitter-c3 v0.2.3:
+
+// Doc comments and contracts
+// -------------------------
+// NOTE parsed by scanner.c (scan_doc_comment_contract_text)
+doc_comment_contract: $ => seq(
+
+	field('name', $.at_ident),
+	optional($.doc_comment_contract_text)
+
+),
+doc_comment: $ => seq(
+
+	'<*',
+	optional($.doc_comment_text), // NOTE parsed by scanner.c (scan_doc_comment_text)
+	repeat($.doc_comment_contract),
+	'*>',
+
+),
+
+// (...)
+
+at_ident: _ => token(seq('@', IDENT)),
+*/
+func (p *Parser) nodeToDocComment(node *sitter.Node, sourceCode []byte) idx.DocComment {
+	body := ""
+	bodyNode := node.Child(1)
+	if bodyNode.Type() == "doc_comment_text" {
+		body = bodyNode.Content(sourceCode)
+	}
+
+	docComment := idx.NewDocComment(body)
+
+	if node.ChildCount() >= 4 {
+		for i := 2; i <= int(node.ChildCount())-2; i++ {
+			contractNode := node.Child(i)
+			if contractNode.Type() == "doc_comment_contract" {
+				name := contractNode.ChildByFieldName("name").Content(sourceCode)
+				body := ""
+				if contractNode.ChildCount() >= 2 {
+					body = contractNode.Child(1).Content(sourceCode)
+				}
+
+				contract := idx.NewDocCommentContract(name, body)
+
+				docComment.AddContracts([]*idx.DocCommentContract{cast.ToPtr(contract)})
+			}
+		}
+	}
+
+	return docComment
+}

--- a/server/pkg/parser/node_to_doc_comment.go
+++ b/server/pkg/parser/node_to_doc_comment.go
@@ -34,17 +34,22 @@ at_ident: _ => token(seq('@', IDENT)),
 */
 func (p *Parser) nodeToDocComment(node *sitter.Node, sourceCode []byte) idx.DocComment {
 	body := ""
+	hasBody := false
 	bodyNode := node.Child(1)
 	if bodyNode.Type() == "doc_comment_text" {
 		// Dedent to accept indented doc strings.
 		body = dedent.Dedent(bodyNode.Content(sourceCode))
+		hasBody = true
 	}
 
 	docComment := idx.NewDocComment(body)
 
-	if node.ChildCount() >= 4 {
-		for i := 2; i <= int(node.ChildCount())-2; i++ {
+	if (hasBody && node.ChildCount() >= 4) || (!hasBody && node.ChildCount() >= 3) {
+		for i := 1; i <= int(node.ChildCount())-2; i++ {
 			contractNode := node.Child(i)
+
+			// Skip the body
+			// (We already skip '<*' and '*>' since we skip first and last indices above)
 			if contractNode.Type() == "doc_comment_contract" {
 				name := contractNode.ChildByFieldName("name").Content(sourceCode)
 				body := ""

--- a/server/pkg/parser/parse_structs_test.go
+++ b/server/pkg/parser/parse_structs_test.go
@@ -41,7 +41,7 @@ fn void MyStruct.init(&self)
 		assert.False(t, found.IsUnion())
 		assert.Equal(t, idx.NewRange(4, 0, 8, 1), found.GetDocumentRange())
 		assert.Equal(t, idx.NewRange(4, 7, 4, 15), found.GetIdRange())
-		assert.Equal(t, "docs", found.GetDocComment())
+		assert.Equal(t, "docs", found.GetDocComment().GetBody())
 	})
 
 	t.Run("finds struct members", func(t *testing.T) {
@@ -160,7 +160,7 @@ struct Foo {
 	assert.Same(t, found.Children()[0], member)
 
 	// Docs here are invalid
-	assert.Equal(t, "", member.GetDocComment())
+	assert.Nil(t, member.GetDocComment())
 }
 
 func TestParses_anonymous_substructs(t *testing.T) {
@@ -320,7 +320,7 @@ func TestParse_Unions(t *testing.T) {
 		assert.True(t, found.IsUnion())
 		assert.Equal(t, idx.NewRange(2, 1, 5, 2), found.GetDocumentRange())
 		assert.Equal(t, idx.NewRange(2, 7, 2, 14), found.GetIdRange())
-		assert.Equal(t, "docs", found.GetDocComment())
+		assert.Equal(t, "docs", found.GetDocComment().GetBody())
 		assert.Same(t, module.Children()[0], found)
 	})
 }
@@ -345,7 +345,7 @@ func TestParse_bitstructs(t *testing.T) {
 		assert.Same(t, symbols.Get("x").Children()[0], found)
 		assert.Equal(t, "Test", found.GetName())
 		assert.Equal(t, "uint", found.Type().GetName())
-		assert.Equal(t, "docs", found.GetDocComment())
+		assert.Equal(t, "docs", found.GetDocComment().GetBody())
 
 		members := found.Members()
 		assert.Equal(t, 3, len(members))

--- a/server/pkg/parser/parser.go
+++ b/server/pkg/parser/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tliron/commonlog"
 )
 
+const DocCommentQuery = `(doc_comment) @doc_comment`
 const VarDeclarationQuery = `(var_declaration
 		name: (identifier) @variable_name
 	)`
@@ -53,6 +54,7 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 	//fmt.Println(doc.URI, doc.ContextSyntaxTree.RootNode())
 
 	query := `[
+(source_file ` + DocCommentQuery + `)
 (source_file ` + ModuleDeclaration + `)
 (source_file ` + ImportDeclaration + `)
 (source_file ` + GlobalVarDeclaration + `)
@@ -85,6 +87,7 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 	var moduleSymbol *idx.Module
 	anonymousModuleName := true
 	lastModuleName := ""
+	lastDocComment := ""
 	//subtyptingToResolve := []StructWithSubtyping{}
 
 	for {
@@ -96,7 +99,7 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 		for _, c := range m.Captures {
 			nodeType := c.Node.Type()
 			nodeEndPoint := idx.NewPositionFromTreeSitterPoint(c.Node.EndPoint())
-			if nodeType != "module" {
+			if nodeType != "module" && nodeType != "doc_comment" {
 				moduleSymbol = parsedModules.GetOrInitModule(
 					lastModuleName,
 					&doc.URI,
@@ -106,6 +109,23 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 			}
 
 			switch nodeType {
+			case "doc_comment":
+				lastDocComment = ""
+				doc_text := c.Node.Child(1)
+				if doc_text.Type() == "doc_comment_text" {
+					lastDocComment = doc_text.Content(sourceCode)
+				}
+				if c.Node.ChildCount() >= 4 {
+					// TODO: Save the contract nodes as structured data for richer information
+					// For now, just append and display their sources
+					for i := 2; i <= int(c.Node.ChildCount())-2; i++ {
+						contract_node := c.Node.Child(i)
+						if contract_node.Type() == "doc_comment_contract" {
+							lastDocComment += "\n" + contract_node.Content(sourceCode)
+						}
+					}
+				}
+
 			case "module":
 				anonymousModuleName = false
 				module, _, _ := p.nodeToModule(doc, c.Node, sourceCode)
@@ -122,6 +142,10 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 				moduleSymbol.SetStartPosition(idx.NewPositionFromTreeSitterPoint(start))
 				moduleSymbol.ChangeModule(lastModuleName)
 
+				if lastDocComment != "" {
+					moduleSymbol.SetDocComment(lastDocComment)
+				}
+
 			case "import_declaration":
 				imports := p.nodeToImport(doc, c.Node, sourceCode)
 				moduleSymbol.AddImports(imports)
@@ -131,16 +155,30 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 				moduleSymbol.AddVariables(variables)
 				pendingToResolve.AddVariableType(variables, moduleSymbol)
 
+				if lastDocComment != "" {
+					for _, v := range variables {
+						v.SetDocComment(lastDocComment)
+					}
+				}
+
 			case "func_definition", "func_declaration":
 				function, err := p.nodeToFunction(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				if err == nil {
 					moduleSymbol.AddFunction(&function)
 					pendingToResolve.AddFunctionTypes(&function, moduleSymbol)
+
+					if lastDocComment != "" {
+						function.SetDocComment(lastDocComment)
+					}
 				}
 
 			case "enum_declaration":
 				enum := p.nodeToEnum(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddEnum(&enum)
+
+				if lastDocComment != "" {
+					enum.SetDocComment(lastDocComment)
+				}
 
 			case "struct_declaration":
 				strukt, membersNeedingSubtypingResolve := p.nodeToStruct(c.Node, moduleSymbol, &doc.URI, sourceCode)
@@ -151,30 +189,58 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 
 				pendingToResolve.AddStructMemberTypes(&strukt, moduleSymbol)
 
+				if lastDocComment != "" {
+					strukt.SetDocComment(lastDocComment)
+				}
+
 			case "bitstruct_declaration":
 				bitstruct := p.nodeToBitStruct(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddBitstruct(&bitstruct)
+
+				if lastDocComment != "" {
+					bitstruct.SetDocComment(lastDocComment)
+				}
 
 			case "define_declaration":
 				def := p.nodeToDef(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddDef(&def)
 				pendingToResolve.AddDefType(&def, moduleSymbol)
 
+				if lastDocComment != "" {
+					def.SetDocComment(lastDocComment)
+				}
+
 			case "const_declaration":
 				_const := p.nodeToConstant(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddVariable(&_const)
+
+				if lastDocComment != "" {
+					_const.SetDocComment(lastDocComment)
+				}
 
 			case "fault_declaration":
 				fault := p.nodeToFault(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddFault(&fault)
 
+				if lastDocComment != "" {
+					fault.SetDocComment(lastDocComment)
+				}
+
 			case "interface_declaration":
 				interf := p.nodeToInterface(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddInterface(&interf)
 
+				if lastDocComment != "" {
+					interf.SetDocComment(lastDocComment)
+				}
+
 			case "macro_declaration":
 				macro := p.nodeToMacro(c.Node, moduleSymbol, &doc.URI, sourceCode)
 				moduleSymbol.AddFunction(&macro)
+
+				if lastDocComment != "" {
+					macro.SetDocComment(lastDocComment)
+				}
 			default:
 				// TODO test that module ends up with wrong endPosition
 				// when this source code:
@@ -183,10 +249,15 @@ func (p *Parser) ParseSymbols(doc *document.Document) (symbols_table.UnitModules
 				// int value = 4;
 				// v
 				// }
+				lastDocComment = ""
 				continue
 			}
 
-			moduleSymbol.SetEndPosition(nodeEndPoint)
+			if nodeType != "doc_comment" {
+				// Ensure the next node won't receive the same doc comment
+				lastDocComment = ""
+				moduleSymbol.SetEndPosition(nodeEndPoint)
+			}
 		}
 	}
 

--- a/server/pkg/parser/parser_functions_test.go
+++ b/server/pkg/parser/parser_functions_test.go
@@ -160,6 +160,11 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 	t.Run("Finds function with simple doc comment", func(t *testing.T) {
 		source := `<*
 			abc
+
+			def
+
+			ghi
+			jkl
 		*>
 		fn void test(int number, char ch, int* pointer) {
 			return 1;
@@ -169,19 +174,28 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		parser := createParser()
 		symbols, _ := parser.ParseSymbols(&doc)
 
+		expectedDoc := `abc
+
+def
+
+ghi
+jkl`
+
 		fn := symbols.Get("docid").GetChildrenFunctionByName("test")
 		assert.True(t, fn.IsSome(), "Function was not found")
 		assert.Equal(t, "test", fn.Get().GetName(), "Function name")
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
-		assert.Equal(t, idx.NewRange(3, 10, 3, 14), fn.Get().GetIdRange())
-		assert.Equal(t, idx.NewRange(3, 2, 5, 3), fn.Get().GetDocumentRange())
-		assert.Equal(t, "abc", fn.Get().GetDocComment().GetBody())
-		assert.Equal(t, "abc", fn.Get().GetDocComment().DisplayBodyWithContracts())
+		assert.Equal(t, idx.NewRange(8, 10, 8, 14), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(8, 2, 10, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, expectedDoc, fn.Get().GetDocComment().GetBody())
+		assert.Equal(t, expectedDoc, fn.Get().GetDocComment().DisplayBodyWithContracts())
 	})
 
 	t.Run("Finds function with doc comment with contracts", func(t *testing.T) {
 		source := `<*
-			abc
+			Hello world.
+			Hello world.
+
 			@pure
 			@param [in] pointer
 			@require number > 0, number < 1000 : "invalid number"
@@ -199,10 +213,12 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.True(t, fn.IsSome(), "Function was not found")
 		assert.Equal(t, "test", fn.Get().GetName(), "Function name")
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
-		assert.Equal(t, idx.NewRange(7, 10, 7, 14), fn.Get().GetIdRange())
-		assert.Equal(t, idx.NewRange(7, 2, 9, 3), fn.Get().GetDocumentRange())
-		assert.Equal(t, "abc", fn.Get().GetDocComment().GetBody())
-		assert.Equal(t, `abc
+		assert.Equal(t, idx.NewRange(9, 10, 9, 14), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(9, 2, 11, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, `Hello world.
+Hello world.`, fn.Get().GetDocComment().GetBody())
+		assert.Equal(t, `Hello world.
+Hello world.
 
 **@pure**
 

--- a/server/pkg/parser/parser_functions_test.go
+++ b/server/pkg/parser/parser_functions_test.go
@@ -61,6 +61,7 @@ func TestExtractSymbols_Functions_Declaration(t *testing.T) {
 		assert.True(t, fn.IsSome(), "Function was not found")
 		assert.Equal(t, "init_window", fn.Get().GetName(), "Function name")
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
+		assert.Equal(t, "", fn.Get().GetDocComment())
 		assert.Equal(t, idx.NewRange(0, 8, 0, 19), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(0, 0, 0, 78), fn.Get().GetDocumentRange())
 	})
@@ -81,6 +82,7 @@ func TestExtractSymbols_Functions_Declaration(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(3, 10, 3, 21), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(3, 2, 3, 80), fn.Get().GetDocumentRange())
+		assert.Equal(t, "abc", fn.Get().GetDocComment())
 	})
 
 	t.Run("Resolves function with unnamed parameters correctly", func(t *testing.T) {
@@ -151,9 +153,31 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(0, 8, 0, 12), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(0, 0, 2, 2), fn.Get().GetDocumentRange())
+		assert.Equal(t, "", fn.Get().GetDocComment())
 	})
 
-	t.Run("Finds function with doc comment", func(t *testing.T) {
+	t.Run("Finds function with simple doc comment", func(t *testing.T) {
+		source := `<*
+			abc
+		*>
+		fn void test(int number, char ch, int* pointer) {
+			return 1;
+		}`
+		docId := "docId"
+		doc := document.NewDocument(docId, source)
+		parser := createParser()
+		symbols, _ := parser.ParseSymbols(&doc)
+
+		fn := symbols.Get("docid").GetChildrenFunctionByName("test")
+		assert.True(t, fn.IsSome(), "Function was not found")
+		assert.Equal(t, "test", fn.Get().GetName(), "Function name")
+		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
+		assert.Equal(t, idx.NewRange(3, 10, 3, 14), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(3, 2, 5, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, "abc", fn.Get().GetDocComment())
+	})
+
+	t.Run("Finds function with doc comment with contracts", func(t *testing.T) {
 		source := `<*
 			abc
 			@pure
@@ -175,6 +199,11 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(7, 10, 7, 14), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(7, 2, 9, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, `abc
+@pure
+@param [in] pointer
+@require number > 0, number < 1000 : "invalid number"
+@ensure return == 1`, fn.Get().GetDocComment())
 	})
 
 	t.Run("Finds function arguments", func(t *testing.T) {

--- a/server/pkg/parser/parser_functions_test.go
+++ b/server/pkg/parser/parser_functions_test.go
@@ -191,7 +191,7 @@ jkl`
 		assert.Equal(t, expectedDoc, fn.Get().GetDocComment().DisplayBodyWithContracts())
 	})
 
-	t.Run("Finds function with doc comment with contracts", func(t *testing.T) {
+	t.Run("Finds function with doc comment with body and contracts", func(t *testing.T) {
 		source := `<*
 			Hello world.
 			Hello world.
@@ -221,6 +221,37 @@ Hello world.`, fn.Get().GetDocComment().GetBody())
 Hello world.
 
 **@pure**
+
+**@param** [in] pointer
+
+**@require** number > 0, number < 1000 : "invalid number"
+
+**@ensure** return == 1`, fn.Get().GetDocComment().DisplayBodyWithContracts())
+	})
+
+	t.Run("Finds function with doc comment with only contracts", func(t *testing.T) {
+		source := `<*
+			@pure
+			@param [in] pointer
+			@require number > 0, number < 1000 : "invalid number"
+			@ensure return == 1
+		*>
+		fn void test(int number, char ch, int* pointer) {
+			return 1;
+		}`
+		docId := "docId"
+		doc := document.NewDocument(docId, source)
+		parser := createParser()
+		symbols, _ := parser.ParseSymbols(&doc)
+
+		fn := symbols.Get("docid").GetChildrenFunctionByName("test")
+		assert.True(t, fn.IsSome(), "Function was not found")
+		assert.Equal(t, "test", fn.Get().GetName(), "Function name")
+		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
+		assert.Equal(t, idx.NewRange(6, 10, 6, 14), fn.Get().GetIdRange())
+		assert.Equal(t, idx.NewRange(6, 2, 8, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, "", fn.Get().GetDocComment().GetBody())
+		assert.Equal(t, `**@pure**
 
 **@param** [in] pointer
 

--- a/server/pkg/parser/parser_functions_test.go
+++ b/server/pkg/parser/parser_functions_test.go
@@ -61,7 +61,7 @@ func TestExtractSymbols_Functions_Declaration(t *testing.T) {
 		assert.True(t, fn.IsSome(), "Function was not found")
 		assert.Equal(t, "init_window", fn.Get().GetName(), "Function name")
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
-		assert.Equal(t, "", fn.Get().GetDocComment())
+		assert.Nil(t, fn.Get().GetDocComment())
 		assert.Equal(t, idx.NewRange(0, 8, 0, 19), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(0, 0, 0, 78), fn.Get().GetDocumentRange())
 	})
@@ -82,7 +82,8 @@ func TestExtractSymbols_Functions_Declaration(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(3, 10, 3, 21), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(3, 2, 3, 80), fn.Get().GetDocumentRange())
-		assert.Equal(t, "abc", fn.Get().GetDocComment())
+		assert.Equal(t, "abc", fn.Get().GetDocComment().GetBody())
+		assert.Equal(t, "abc", fn.Get().GetDocComment().DisplayBodyWithContracts())
 	})
 
 	t.Run("Resolves function with unnamed parameters correctly", func(t *testing.T) {
@@ -153,7 +154,7 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(0, 8, 0, 12), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(0, 0, 2, 2), fn.Get().GetDocumentRange())
-		assert.Equal(t, "", fn.Get().GetDocComment())
+		assert.Nil(t, fn.Get().GetDocComment())
 	})
 
 	t.Run("Finds function with simple doc comment", func(t *testing.T) {
@@ -174,7 +175,8 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(3, 10, 3, 14), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(3, 2, 5, 3), fn.Get().GetDocumentRange())
-		assert.Equal(t, "abc", fn.Get().GetDocComment())
+		assert.Equal(t, "abc", fn.Get().GetDocComment().GetBody())
+		assert.Equal(t, "abc", fn.Get().GetDocComment().DisplayBodyWithContracts())
 	})
 
 	t.Run("Finds function with doc comment with contracts", func(t *testing.T) {
@@ -199,11 +201,16 @@ func TestExtractSymbols_FunctionsWithArguments(t *testing.T) {
 		assert.Equal(t, "void", fn.Get().GetReturnType().GetName(), "Return type")
 		assert.Equal(t, idx.NewRange(7, 10, 7, 14), fn.Get().GetIdRange())
 		assert.Equal(t, idx.NewRange(7, 2, 9, 3), fn.Get().GetDocumentRange())
+		assert.Equal(t, "abc", fn.Get().GetDocComment().GetBody())
 		assert.Equal(t, `abc
-@pure
-@param [in] pointer
-@require number > 0, number < 1000 : "invalid number"
-@ensure return == 1`, fn.Get().GetDocComment())
+
+**@pure**
+
+**@param** [in] pointer
+
+**@require** number > 0, number < 1000 : "invalid number"
+
+**@ensure** return == 1`, fn.Get().GetDocComment().DisplayBodyWithContracts())
 	})
 
 	t.Run("Finds function arguments", func(t *testing.T) {

--- a/server/pkg/parser/parser_test.go
+++ b/server/pkg/parser/parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/pherrymason/c3-lsp/pkg/cast"
 	"github.com/pherrymason/c3-lsp/pkg/document"
 	"github.com/pherrymason/c3-lsp/pkg/option"
 	idx "github.com/pherrymason/c3-lsp/pkg/symbols"
@@ -62,7 +63,7 @@ func TestParses_TypedEnums(t *testing.T) {
 		scope := symbols.Get("doc")
 		enum := scope.Enums["Colors"]
 
-		assert.Equal(t, "abc", enum.GetDocComment())
+		assert.Equal(t, "abc", enum.GetDocComment().GetBody())
 	})
 
 	t.Run("finds defined enumerators", func(t *testing.T) {
@@ -145,7 +146,7 @@ func TestParses_UnTypedEnums(t *testing.T) {
 		scope := symbols.Get("doc")
 		enum := scope.Enums["Colors"]
 
-		assert.Equal(t, "abc", enum.GetDocComment())
+		assert.Equal(t, "abc", enum.GetDocComment().GetBody())
 	})
 
 	t.Run("finds defined enumerators", func(t *testing.T) {
@@ -201,7 +202,7 @@ func TestParse_fault(t *testing.T) {
 
 		fault := symbols.Get("doc").Faults["IOResult"]
 
-		assert.Equal(t, "docs", fault.GetDocComment())
+		assert.Equal(t, "docs", fault.GetDocComment().GetBody())
 	})
 
 	t.Run("finds defined fault constants", func(t *testing.T) {
@@ -258,7 +259,7 @@ func TestParse_interface(t *testing.T) {
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		found := symbols.Get("doc").Interfaces["MyName"]
-		assert.Equal(t, "docs", found.GetDocComment())
+		assert.Equal(t, "docs", found.GetDocComment().GetBody())
 	})
 
 	t.Run("finds defined methods in interface", func(t *testing.T) {
@@ -298,7 +299,7 @@ func TestExtractSymbols_finds_definition(t *testing.T) {
 		WithIdentifierRange(2, 5, 2, 9).
 		WithDocumentRange(2, 1, 2, 16).
 		Build()
-	expectedDefKilo.SetDocComment("docs")
+	expectedDefKilo.SetDocComment(cast.ToPtr(idx.NewDocComment("docs")))
 	assert.Equal(t, expectedDefKilo, module.Defs["Kilo"])
 	assert.Same(t, module.Children()[0], module.Defs["Kilo"])
 
@@ -377,7 +378,7 @@ func TestExtractSymbols_find_macro(t *testing.T) {
 	assert.Equal(t, "m", fn.Get().GetName())
 	assert.Equal(t, "x", fn.Get().Variables["x"].GetName())
 	assert.Equal(t, "", fn.Get().Variables["x"].GetType().String())
-	assert.Equal(t, "docs", fn.Get().GetDocComment())
+	assert.Equal(t, "docs", fn.Get().GetDocComment().GetBody())
 	assert.Same(t, module.NestedScopes()[0], fn.Get())
 }
 
@@ -406,7 +407,7 @@ func TestExtractSymbols_find_module(t *testing.T) {
 
 		module := symbols.Get("foo")
 		assert.Equal(t, "foo", module.GetModuleString(), "module name is wrong")
-		assert.Equal(t, "docs", module.GetDocComment(), "module doc comment is wrong")
+		assert.Equal(t, "docs", module.GetDocComment().GetBody(), "module doc comment is wrong")
 	})
 
 	t.Run("finds different modules defined in single file", func(t *testing.T) {
@@ -426,13 +427,13 @@ func TestExtractSymbols_find_module(t *testing.T) {
 		module := symbols.Get("foo")
 		assert.Equal(t, "foo", module.GetModuleString(), "module name is wrong")
 		assert.Equal(t, "foo", module.GetName(), "module name is wrong")
-		assert.Equal(t, "docs foo", module.GetDocComment(), "module doc comment is wrong")
+		assert.Equal(t, "docs foo", module.GetDocComment().GetBody(), "module doc comment is wrong")
 		assert.Equal(t, idx.NewRange(2, 1, 3, 15), module.GetDocumentRange(), "Wrong range for foo module")
 
 		module = symbols.Get("foo2")
 		assert.Equal(t, "foo2", module.GetModuleString(), "module name is wrong")
 		assert.Equal(t, "foo2", module.GetName(), "module name is wrong")
-		assert.Equal(t, "docs foo2", module.GetDocComment(), "module doc comment is wrong")
+		assert.Equal(t, "docs foo2", module.GetDocComment().GetBody(), "module doc comment is wrong")
 		assert.Equal(t, idx.NewRange(6, 1, 7, 15), module.GetDocumentRange(), "Wrong range for foo2 module")
 	})
 

--- a/server/pkg/parser/parser_variables_test.go
+++ b/server/pkg/parser/parser_variables_test.go
@@ -38,7 +38,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
 		assert.Equal(t, idx.NewRange(2, 1, 2, 15), found.GetDocumentRange())
 		assert.Equal(t, idx.NewRange(2, 5, 2, 10), found.GetIdRange())
-		assert.Equal(t, "docs", found.GetDocComment(), "Variable docs")
+		assert.Equal(t, "docs", found.GetDocComment().GetBody(), "Variable docs")
 		assert.Equal(t, 0, len(pendingToResolve.GetTypesByModule(docId)), "Basic types should not be registered as pending to resolve.")
 	})
 
@@ -88,7 +88,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
 		assert.Equal(t, idx.NewRange(line, 5, line, 8), found.GetIdRange(), "First variable identifier range")
 		assert.Equal(t, idx.NewRange(line, 1, line, 15), found.GetDocumentRange(), "First variable declaration range")
-		assert.Equal(t, "multidocs", found.GetDocComment())
+		assert.Equal(t, "multidocs", found.GetDocComment().GetBody())
 
 		found = symbols.Get("x").Variables["foo2"]
 		assert.Equal(t, "foo2", found.GetName(), "Second variable name")
@@ -96,7 +96,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
 		assert.Equal(t, idx.NewRange(line, 10, line, 14), found.GetIdRange(), "Second variable identifier range")
 		assert.Equal(t, idx.NewRange(line, 1, line, 15), found.GetDocumentRange(), "Second variable declaration range")
-		assert.Equal(t, "multidocs", found.GetDocComment())
+		assert.Equal(t, "multidocs", found.GetDocComment().GetBody())
 	})
 
 	t.Run("finds variables declared inside function", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestExtractSymbols_find_constants(t *testing.T) {
 	assert.True(t, found.IsConstant())
 	assert.Equal(t, idx.NewRange(1, 1, 1, 24), found.GetDocumentRange())
 	assert.Equal(t, idx.NewRange(1, 11, 1, 18), found.GetIdRange())
-	assert.Equal(t, "docs", found.GetDocComment(), "Variable doc comment")
+	assert.Equal(t, "docs", found.GetDocComment().GetBody(), "Variable doc comment")
 }
 
 func TestExtractSymbols_find_variables_flag_pending_to_resolve(t *testing.T) {

--- a/server/pkg/parser/parser_variables_test.go
+++ b/server/pkg/parser/parser_variables_test.go
@@ -15,8 +15,10 @@ func assertVariableFound(t *testing.T, name string, symbols idx.Function) {
 
 func TestExtractSymbols_find_variables(t *testing.T) {
 	source := `
+	<* docs *>
 	int value = 1;
 	char* character;
+	<* multidocs *>
 	int foo, foo2;
 	char[] message;
 	char[4] message2;
@@ -34,13 +36,14 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, "value", found.GetName(), "Variable name")
 		assert.Equal(t, "int", found.GetType().String(), "Variable type")
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
-		assert.Equal(t, idx.NewRange(1, 1, 1, 15), found.GetDocumentRange())
-		assert.Equal(t, idx.NewRange(1, 5, 1, 10), found.GetIdRange())
+		assert.Equal(t, idx.NewRange(2, 1, 2, 15), found.GetDocumentRange())
+		assert.Equal(t, idx.NewRange(2, 5, 2, 10), found.GetIdRange())
+		assert.Equal(t, "docs", found.GetDocComment(), "Variable docs")
 		assert.Equal(t, 0, len(pendingToResolve.GetTypesByModule(docId)), "Basic types should not be registered as pending to resolve.")
 	})
 
 	t.Run("finds global pointer variable declarations", func(t *testing.T) {
-		line := uint(2)
+		line := uint(3)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		found := symbols.Get("x").Variables["character"]
@@ -52,7 +55,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 	})
 
 	t.Run("finds global variable collection declarations", func(t *testing.T) {
-		line := uint(4)
+		line := uint(6)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		found := symbols.Get("x").Variables["message"]
@@ -64,7 +67,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 	})
 
 	t.Run("finds global variable static collection declarations", func(t *testing.T) {
-		line := uint(5)
+		line := uint(7)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		found := symbols.Get("x").Variables["message2"]
@@ -76,7 +79,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 	})
 
 	t.Run("finds multiple global variables declared in single sentence", func(t *testing.T) {
-		line := uint(3)
+		line := uint(5)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		found := symbols.Get("x").Variables["foo"]
@@ -85,6 +88,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
 		assert.Equal(t, idx.NewRange(line, 5, line, 8), found.GetIdRange(), "First variable identifier range")
 		assert.Equal(t, idx.NewRange(line, 1, line, 15), found.GetDocumentRange(), "First variable declaration range")
+		assert.Equal(t, "multidocs", found.GetDocComment())
 
 		found = symbols.Get("x").Variables["foo2"]
 		assert.Equal(t, "foo2", found.GetName(), "Second variable name")
@@ -92,10 +96,11 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 		assert.Equal(t, true, found.GetType().IsBaseTypeLanguage(), "Variable Type should be base type")
 		assert.Equal(t, idx.NewRange(line, 10, line, 14), found.GetIdRange(), "Second variable identifier range")
 		assert.Equal(t, idx.NewRange(line, 1, line, 15), found.GetDocumentRange(), "Second variable declaration range")
+		assert.Equal(t, "multidocs", found.GetDocComment())
 	})
 
 	t.Run("finds variables declared inside function", func(t *testing.T) {
-		line := uint(6)
+		line := uint(8)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		function := symbols.Get("x").GetChildrenFunctionByName("test")
@@ -110,7 +115,7 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 	})
 
 	t.Run("finds multiple local variables declared in single sentence", func(t *testing.T) {
-		line := uint(7)
+		line := uint(9)
 		symbols, _ := parser.ParseSymbols(&doc)
 
 		function := symbols.Get("x").GetChildrenFunctionByName("test2")
@@ -133,7 +138,8 @@ func TestExtractSymbols_find_variables(t *testing.T) {
 
 func TestExtractSymbols_find_constants(t *testing.T) {
 
-	source := `const int A_VALUE = 12;`
+	source := `<* docs *>
+	const int A_VALUE = 12;`
 
 	doc := document.NewDocument("docId", source)
 	parser := createParser()
@@ -144,8 +150,9 @@ func TestExtractSymbols_find_constants(t *testing.T) {
 	assert.Equal(t, "A_VALUE", found.GetName(), "Variable name")
 	assert.Equal(t, "int", found.GetType().String(), "Variable type")
 	assert.True(t, found.IsConstant())
-	assert.Equal(t, idx.NewRange(0, 0, 0, 23), found.GetDocumentRange())
-	assert.Equal(t, idx.NewRange(0, 10, 0, 17), found.GetIdRange())
+	assert.Equal(t, idx.NewRange(1, 1, 1, 24), found.GetDocumentRange())
+	assert.Equal(t, idx.NewRange(1, 11, 1, 18), found.GetIdRange())
+	assert.Equal(t, "docs", found.GetDocComment(), "Variable doc comment")
 }
 
 func TestExtractSymbols_find_variables_flag_pending_to_resolve(t *testing.T) {

--- a/server/pkg/symbols/doc_comment.go
+++ b/server/pkg/symbols/doc_comment.go
@@ -1,0 +1,51 @@
+package symbols
+
+type DocCommentContract struct {
+	name string
+	body string
+}
+
+type DocComment struct {
+	body      string
+	contracts []*DocCommentContract
+}
+
+// Creates a doc comment with the given body.
+func NewDocComment(body string) DocComment {
+	return DocComment{
+		body:      body,
+		contracts: []*DocCommentContract{},
+	}
+}
+
+// Creates a contract with the given name and body.
+// It is expected that the name begins with '@'.
+func NewDocCommentContract(name string, body string) DocCommentContract {
+	return DocCommentContract{
+		name,
+		body,
+	}
+}
+
+// Add contracts to the given doc comment.
+func (d *DocComment) AddContracts(contracts []*DocCommentContract) {
+	d.contracts = append(d.contracts, contracts...)
+}
+
+func (d *DocComment) GetBody() string {
+	return d.body
+}
+
+// Return a string displaying the body and contracts as markdown.
+func (d *DocComment) DisplayBodyWithContracts() string {
+	out := d.body
+
+	for _, c := range d.contracts {
+		out += "\n\n**" + c.name + "**"
+		if c.body != "" {
+			out += " " + c.body
+		}
+	}
+
+	return out
+}

--- a/server/pkg/symbols/doc_comment.go
+++ b/server/pkg/symbols/doc_comment.go
@@ -41,7 +41,10 @@ func (d *DocComment) DisplayBodyWithContracts() string {
 	out := d.body
 
 	for _, c := range d.contracts {
-		out += "\n\n**" + c.name + "**"
+		if out != "" {
+			out += "\n\n"
+		}
+		out += "**" + c.name + "**"
 		if c.body != "" {
 			out += " " + c.body
 		}

--- a/server/pkg/symbols/indexable.go
+++ b/server/pkg/symbols/indexable.go
@@ -33,7 +33,7 @@ type Indexable interface {
 	GetModule() ModulePath
 	IsSubModuleOf(parentModule ModulePath) bool
 
-	GetDocComment() string
+	GetDocComment() *DocComment
 	GetHoverInfo() string
 	HasSourceCode() bool // This will return false for that code that is not accesible either because it belongs to the stdlib, or inside a .c3lib library. This results in disabling "Go to definition" / "Go to declaration" on these symbols
 
@@ -60,7 +60,7 @@ type BaseIndexable struct {
 	idRange       Range
 	docRange      Range
 	Kind          protocol.CompletionItemKind
-	docComment    string
+	docComment    *DocComment
 	attributes    []string
 
 	children      []Indexable
@@ -125,7 +125,7 @@ func (b *BaseIndexable) SetDocumentURI(docId string) {
 	b.documentURI = docId
 }
 
-func (b *BaseIndexable) GetDocComment() string {
+func (b *BaseIndexable) GetDocComment() *DocComment {
 	return b.docComment
 }
 
@@ -162,7 +162,7 @@ func (b *BaseIndexable) InsertNestedScope(symbol Indexable) {
 	b.nestedScopes = append(b.nestedScopes, symbol)
 }
 
-func (b *BaseIndexable) SetDocComment(docComment string) {
+func (b *BaseIndexable) SetDocComment(docComment *DocComment) {
 	b.docComment = docComment
 }
 
@@ -180,7 +180,7 @@ func NewBaseIndexable(name string, module string, docId protocol.DocumentUri, id
 		docRange:      docRange,
 		Kind:          kind,
 		hasSourceCode: true,
-		docComment:    "",
+		docComment:    nil,
 		attributes:    []string{},
 	}
 }

--- a/server/pkg/symbols/indexable.go
+++ b/server/pkg/symbols/indexable.go
@@ -33,6 +33,7 @@ type Indexable interface {
 	GetModule() ModulePath
 	IsSubModuleOf(parentModule ModulePath) bool
 
+	GetDocComment() string
 	GetHoverInfo() string
 	HasSourceCode() bool // This will return false for that code that is not accesible either because it belongs to the stdlib, or inside a .c3lib library. This results in disabling "Go to definition" / "Go to declaration" on these symbols
 
@@ -59,6 +60,7 @@ type BaseIndexable struct {
 	idRange       Range
 	docRange      Range
 	Kind          protocol.CompletionItemKind
+	docComment    string
 	attributes    []string
 
 	children      []Indexable
@@ -123,6 +125,10 @@ func (b *BaseIndexable) SetDocumentURI(docId string) {
 	b.documentURI = docId
 }
 
+func (b *BaseIndexable) GetDocComment() string {
+	return b.docComment
+}
+
 func (b *BaseIndexable) GetAttributes() []string {
 	return b.attributes
 }
@@ -156,6 +162,10 @@ func (b *BaseIndexable) InsertNestedScope(symbol Indexable) {
 	b.nestedScopes = append(b.nestedScopes, symbol)
 }
 
+func (b *BaseIndexable) SetDocComment(docComment string) {
+	b.docComment = docComment
+}
+
 func (b *BaseIndexable) formatSource(source string) string {
 	return fmt.Sprintf("```c3\n%s```", source)
 }
@@ -170,6 +180,7 @@ func NewBaseIndexable(name string, module string, docId protocol.DocumentUri, id
 		docRange:      docRange,
 		Kind:          kind,
 		hasSourceCode: true,
+		docComment:    "",
 		attributes:    []string{},
 	}
 }


### PR DESCRIPTION
Closes #72 ~~(still WIP)~~

~~Right now, neither feature works at all in VSCode for some reason. I'm not sure if this is a problem with the extension or with server/client capabilities or something else, but currently, with this PR's changes, the language server is just returning `null` for any hover or completion with documentation in VSCode, meaning items with documentation are just not suggested / have no hover anymore. I'll try to investigate, but for now, all screenshots below use the Zed extension.~~

**EDIT: It works in VSCode.** Turns out I wasn't telling VSCode to use my build, so it was using an outdated version of the LSP. Whoops :)

In addition to trying to get the VSCode extension to work, I'd like to implement at least the following changes:

- [x] Creating a proper doc comment structure which separates main doc body from contracts (right now it's just a plain string). This will allow us to only send the doc body on completions instead of also including contracts. In addition, it allows us to properly structure contracts visually on hover.
    - To be honest, I'm not entirely sure whether we should omit contracts from completions as long doc strings can happen anyway, and would be shown separately. But I think this is a good heuristic for now and keeps the list of completions more compact.
- [x] Automatically remove common indentation from the doc comment body.
- [x] We could also consider adding function documentation to signature help; I'll leave this as a separate and optional task (although it's probably quite trivial, but would need some additional testing).
    - Done, although it's currently missing docs for individual parameters, but that'd need some additional work to parse `@param` docs.

## Future work
- Parse param docs (e.g. ``@param value `The requested value.` ``)

## Screenshots

### VSCode

![hover shows doc](https://github.com/user-attachments/assets/523fed01-0503-454a-bcfe-f04df47194c7)
![complex docs](https://github.com/user-attachments/assets/58c547bc-72f9-4ba5-b5bd-2b8d3242ea39)
![module docs on hover](https://github.com/user-attachments/assets/26f00990-16b6-4d6b-8b15-a1625a2b1a42)


Unfortunately, VSCode doesn't support showing documentation directly on completions; however, they can be manually shown with `Ctrl/Cmd + I`:

![doc on completion](https://github.com/user-attachments/assets/0533ebb9-a476-4bbf-bdbf-cc32884f645f)

### Zed

![hovering over function name shows doc](https://github.com/user-attachments/assets/87ba199a-d101-4a1d-ac50-391bbab3c574)
![completion shows doc](https://github.com/user-attachments/assets/68e1b671-fb96-4099-b685-71fd6868ec76)
![type doc on hover](https://github.com/user-attachments/assets/1b2ec71f-d4d0-49c6-95a0-530936780b32)
![module doc on hover](https://github.com/user-attachments/assets/82ea94e5-dfe9-4a7c-9947-4049871dbb44)
