### PR TITLE
Slightly improve function hover

### DIFF
--- a/server/pkg/symbols/function.go
+++ b/server/pkg/symbols/function.go
@@ -150,7 +150,7 @@ func (f Function) GetHoverInfo() string {
 		args = append(args, f.Variables[arg].Type.String()+" "+f.Variables[arg].name)
 	}
 
-	source := fmt.Sprintf("%s %s(%s)", f.GetReturnType(), f.GetFullName(), strings.Join(args, ", "))
+	source := fmt.Sprintf("fn %s %s(%s)", f.GetReturnType(), f.GetFullName(), strings.Join(args, ", "))
 
 	return source
 }


### PR DESCRIPTION
Adds the `fn` keyword before function hover info to ensure proper syntax highlighting.

It's possible there are other places where this change would be appropriate, but this was the only one where the status quo appeared to actually break syntax highlighting.

Before PR:
![function hover syntax highlighting is broken on Zed](https://github.com/user-attachments/assets/9f2e9aa7-8909-43ae-873f-1dc3867c2e8e)
![function hover syntax highlighting is fine but not the best on VSCode](https://github.com/user-attachments/assets/f7f9e581-3fb0-44d5-95de-c9c91242b35a)


After PR:
![function hover syntax highlighting fully functional](https://github.com/user-attachments/assets/f0cb4d1c-23d4-423b-bc7b-a8a13740bb13)
![function hover syntax highlighting fully functional](https://github.com/user-attachments/assets/083cb57a-99f7-4cc2-9902-7f9eeb64aa22)
