### PR TITLE
Add completion detail

### DIFF
--- a/server/internal/lsp/search/search_completion_list.go
+++ b/server/internal/lsp/search/search_completion_list.go
@@ -142,6 +142,15 @@ func GetCompletableDocComment(s symbols.Indexable) any {
 	}
 }
 
+func GetCompletionDetail(s symbols.Indexable) *string {
+	detail := s.GetCompletionDetail()
+	if detail == "" {
+		return nil
+	} else {
+		return &detail
+	}
+}
+
 // Returns: []CompletionItem | CompletionList | nil
 func (s *Search) BuildCompletionList(
 	ctx context.CursorContext,
@@ -240,6 +249,8 @@ func (s *Search) BuildCompletionList(
 
 						// At this moment, struct members cannot receive documentation
 						Documentation: nil,
+
+						Detail: GetCompletionDetail(member),
 					})
 				}
 			}
@@ -271,6 +282,7 @@ func (s *Search) BuildCompletionList(
 						Range:   replacementRange,
 					},
 					Documentation: GetCompletableDocComment(fn),
+					Detail:        GetCompletionDetail(fn),
 				})
 			}
 
@@ -284,6 +296,8 @@ func (s *Search) BuildCompletionList(
 
 						// No documentation for enumerators at this time
 						Documentation: nil,
+
+						Detail: GetCompletionDetail(enumerator),
 					})
 				}
 			}
@@ -298,6 +312,8 @@ func (s *Search) BuildCompletionList(
 
 						// No documentation for fault constants at this time
 						Documentation: nil,
+
+						Detail: GetCompletionDetail(constant),
 					})
 				}
 			}
@@ -328,20 +344,21 @@ func (s *Search) BuildCompletionList(
 				editRange := symbolInPosition.FullTextRange().ToLSP()
 
 				items = append(items, protocol.CompletionItem{
-					Label:  storedIdentifier.GetName(),
-					Kind:   cast.ToPtr(storedIdentifier.GetKind()),
-					Detail: cast.ToPtr("Module"),
+					Label: storedIdentifier.GetName(),
+					Kind:  cast.ToPtr(storedIdentifier.GetKind()),
 					TextEdit: protocol.TextEdit{
 						NewText: storedIdentifier.GetName(),
 						Range:   editRange,
 					},
 					Documentation: GetCompletableDocComment(storedIdentifier),
+					Detail:        GetCompletionDetail(storedIdentifier),
 				})
 			} else {
 				items = append(items, protocol.CompletionItem{
 					Label:         storedIdentifier.GetName(),
 					Kind:          cast.ToPtr(storedIdentifier.GetKind()),
 					Documentation: GetCompletableDocComment(storedIdentifier),
+					Detail:        GetCompletionDetail(storedIdentifier),
 				})
 			}
 		}

--- a/server/internal/lsp/search/search_completion_list_test.go
+++ b/server/internal/lsp/search/search_completion_list_test.go
@@ -863,26 +863,26 @@ func TestBuildCompletionList_enums(t *testing.T) {
 				"Find enumerables starting with string",
 				"CO",
 				[]protocol.CompletionItem{
-					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("COH", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("COUGH", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("COUGHCOUGH", protocol.CompletionItemKindEnumMember, "Enumerator"),
+					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("COH", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("COUGH", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("COUGHCOUGH", protocol.CompletionItemKindEnumMember, "Enum Value"),
 				}},
 
 			{
 				"Find all enum enumerables when prefixed with enum name",
 				"Color.",
 				[]protocol.CompletionItem{
-					CreateCompletionItem("BLUE", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("GREEN", protocol.CompletionItemKindEnumMember, "Enumerator"),
-					CreateCompletionItem("RED", protocol.CompletionItemKindEnumMember, "Enumerator"),
+					CreateCompletionItem("BLUE", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("GREEN", protocol.CompletionItemKindEnumMember, "Enum Value"),
+					CreateCompletionItem("RED", protocol.CompletionItemKindEnumMember, "Enum Value"),
 				}},
 			{
 				"Find matching enum enumerables",
 				"Color.COB",
 				[]protocol.CompletionItem{
-					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enumerator"),
+					CreateCompletionItem("COBALT", protocol.CompletionItemKindEnumMember, "Enum Value"),
 				},
 			},
 		}

--- a/server/pkg/symbols/bitstruct.go
+++ b/server/pkg/symbols/bitstruct.go
@@ -42,3 +42,8 @@ func (b Bitstruct) Members() []*StructMember {
 func (b Bitstruct) GetHoverInfo() string {
 	return b.name
 }
+
+func (b Bitstruct) GetCompletionDetail() string {
+	// Same rationale as for struct
+	return "Type"
+}

--- a/server/pkg/symbols/def.go
+++ b/server/pkg/symbols/def.go
@@ -69,11 +69,11 @@ func (d Def) GetCompletionDetail() string {
 	if d.resolvesToType.IsSome() {
 		return "Type"
 	} else if strings.HasPrefix(d.name, "@") {
-		return "Macro Alias"
+		return "Alias for macro '" + d.resolvesTo + "'"
 	} else {
 		// No semantic information
-		// TODO: Resolve the identifier and display it?
-		return "Alias"
+		// TODO: Resolve the identifier and display its information?
+		return "Alias for '" + d.resolvesTo + "'"
 	}
 }
 

--- a/server/pkg/symbols/def.go
+++ b/server/pkg/symbols/def.go
@@ -65,6 +65,18 @@ func (d Def) GetHoverInfo() string {
 	return fmt.Sprintf("def %s = %s", d.name, resolvesTo)
 }
 
+func (d Def) GetCompletionDetail() string {
+	if d.resolvesToType.IsSome() {
+		return "Type"
+	} else if strings.HasPrefix(d.name, "@") {
+		return "Macro Alias"
+	} else {
+		// No semantic information
+		// TODO: Resolve the identifier and display it?
+		return "Alias"
+	}
+}
+
 func (d Def) ResolvesToType() bool {
 	return d.resolvesToType.IsSome()
 }

--- a/server/pkg/symbols/enum.go
+++ b/server/pkg/symbols/enum.go
@@ -72,3 +72,10 @@ func (e Enum) GetEnumerators() []*Enumerator {
 func (e Enum) GetHoverInfo() string {
 	return e.name
 }
+
+func (e Enum) GetCompletionDetail() string {
+	// While we could specify 'Type' here like in struct,
+	// enums behave quite differently overall, especially
+	// regarding instantiation
+	return "Enum"
+}

--- a/server/pkg/symbols/enumerator.go
+++ b/server/pkg/symbols/enumerator.go
@@ -36,3 +36,7 @@ func NewEnumerator(name string, value string, associatedValues []Variable, modul
 func (e Enumerator) GetHoverInfo() string {
 	return fmt.Sprintf("%s: %s", e.name, e.value)
 }
+
+func (e Enumerator) GetCompletionDetail() string {
+	return "Enumerator"
+}

--- a/server/pkg/symbols/enumerator.go
+++ b/server/pkg/symbols/enumerator.go
@@ -38,5 +38,5 @@ func (e Enumerator) GetHoverInfo() string {
 }
 
 func (e Enumerator) GetCompletionDetail() string {
-	return "Enumerator"
+	return "Enum Value"
 }

--- a/server/pkg/symbols/fault.go
+++ b/server/pkg/symbols/fault.go
@@ -83,12 +83,20 @@ func (e Fault) GetHoverInfo() string {
 	return e.name
 }
 
+func (e Fault) GetCompletionDetail() string {
+	return "Fault"
+}
+
 type FaultConstant struct {
 	BaseIndexable
 }
 
 func (e FaultConstant) GetHoverInfo() string {
 	return e.name
+}
+
+func (e FaultConstant) GetCompletionDetail() string {
+	return "Fault Constant"
 }
 
 func NewFaultConstant(name string, idRange Range) *FaultConstant {

--- a/server/pkg/symbols/function.go
+++ b/server/pkg/symbols/function.go
@@ -223,3 +223,8 @@ func (f *Function) SetEndPosition(position Position) {
 func (f Function) GetHoverInfo() string {
 	return f.DisplaySignature(true)
 }
+
+func (f Function) GetCompletionDetail() string {
+	// Since this is just the type of the function, we don't include its name
+	return f.DisplaySignature(false)
+}

--- a/server/pkg/symbols/generic_parameter.go
+++ b/server/pkg/symbols/generic_parameter.go
@@ -22,3 +22,7 @@ func NewGenericParameter(name string, module string, docId string, idRange Range
 func (g GenericParameter) GetHoverInfo() string {
 	return g.GetName()
 }
+
+func (g GenericParameter) GetCompletionDetail() string {
+	return "Type Parameter"
+}

--- a/server/pkg/symbols/indexable.go
+++ b/server/pkg/symbols/indexable.go
@@ -35,6 +35,7 @@ type Indexable interface {
 
 	GetDocComment() *DocComment
 	GetHoverInfo() string
+	GetCompletionDetail() string
 	HasSourceCode() bool // This will return false for that code that is not accesible either because it belongs to the stdlib, or inside a .c3lib library. This results in disabling "Go to definition" / "Go to declaration" on these symbols
 
 	Children() []Indexable

--- a/server/pkg/symbols/interface.go
+++ b/server/pkg/symbols/interface.go
@@ -39,3 +39,7 @@ func (i *Interface) AddMethods(methods []*Function) {
 func (i Interface) GetHoverInfo() string {
 	return fmt.Sprintf("%s", i.name)
 }
+
+func (i Interface) GetCompletionDetail() string {
+	return "Interface"
+}

--- a/server/pkg/symbols/module.go
+++ b/server/pkg/symbols/module.go
@@ -139,6 +139,10 @@ func (m *Module) GetHoverInfo() string {
 	return m.name
 }
 
+func (m *Module) GetCompletionDetail() string {
+	return "Module"
+}
+
 func (m *Module) GetChildrenFunctionByName(name string) option.Option[*Function] {
 	for _, fun := range m.ChildrenFunctions {
 		if fun.GetFullName() == name {

--- a/server/pkg/symbols/struct.go
+++ b/server/pkg/symbols/struct.go
@@ -73,6 +73,11 @@ func (s Struct) GetHoverInfo() string {
 	return fmt.Sprintf("%s", s.name)
 }
 
+func (s Struct) GetCompletionDetail() string {
+	// More information on completion probably isn't needed
+	return "Type"
+}
+
 func (s *Struct) InheritMembersFrom(inlinedMemberName string, otherStruct *Struct) {
 	for _, member := range s.GetMembers() {
 		if member.GetType().GetName() == inlinedMemberName {
@@ -122,6 +127,15 @@ func (m StructMember) GetBitRange() [2]uint {
 
 func (s StructMember) GetHoverInfo() string {
 	return fmt.Sprintf("%s %s", s.baseType, s.name)
+}
+
+func (s StructMember) GetCompletionDetail() string {
+	if s.isStruct {
+		// Anonymous substruct, not much to say
+		return fmt.Sprintf("Struct member '%s'", s.subStruct.Get().name)
+	} else {
+		return s.GetType().String()
+	}
 }
 
 func NewStructMember(name string, fieldType Type, bitRanges option.Option[[2]uint], module string, docId string, idRange Range) StructMember {

--- a/server/pkg/symbols/variable.go
+++ b/server/pkg/symbols/variable.go
@@ -50,3 +50,7 @@ func (v Variable) IsConstant() bool {
 func (v Variable) GetHoverInfo() string {
 	return fmt.Sprintf("%s %s", v.GetType(), v.GetName())
 }
+
+func (v Variable) GetCompletionDetail() string {
+	return v.GetType().String()
+}


### PR DESCRIPTION
~~Draft as I couldn't get it to work with Zed for some reason, right now only VSCode is working. Will investigate.~~

(**EDIT:** Turns out this will require a PR to [`c3-zed`](https://github.com/AineeJames/c3-zed) to work with Zed. That means it isn't the LSP's fault, so the PR itself should be fine. However, I'll keep it as a draft as I'll need to rebase on #103 later. **(Done!)**)

Basically, this adds type information as well as other information to completions, making them more immediately helpful.

This was inspired by a similar feature in the [Gleam language's LSP](https://github.com/gleam-lang/gleam).

I chose to simply add a "Type" hint for struct, bitstruct and union as I felt like being more specific wouldn't be too helpful, but let me know if you'd prefer to have "Struct", "Bitstruct" and "Union" instead (I'd be ok with that as well, the former just felt a bit cleaner to me, but I don't mind it that much).

~~I also chose "Enumerator" for enum values, but I'm thinking of writing just "Enum value" as that's clearer.~~ (Changed to "Enum Value")

Also, I chose "Fault Constant" for fault constants and "Struct member 'name'" for anonymous substructs.

In addition, `def`s display "Type" when they're type aliases, or "Alias for '<alias in definition RHS>'" otherwise since we have little to no semantic information (as an exception, I also display "Alias for macro '@macroname'" when we know for sure it's a macro due to `@`).

## Future work

- Perhaps some way to resolve the definition RHS to display better information would be nice.

## Screenshots

![shows var type 1](https://github.com/user-attachments/assets/4f74e96e-0e87-44e2-83ef-05b5d15551c9)
![shows var type 2](https://github.com/user-attachments/assets/7aea2dab-2869-4d59-b274-4f0fbd4393e0)
![shows function signature](https://github.com/user-attachments/assets/c0ae39af-61fe-480f-b3bd-4f68befd5db0)
![shows local var type](https://github.com/user-attachments/assets/2b494938-d806-44bb-a406-8b5e45ca4994)
![shows "Type" for struct](https://github.com/user-attachments/assets/d7cf9d0f-7f27-4608-b814-baaa339097a6)
![shows "Enumerator" for enum value](https://github.com/user-attachments/assets/4710df8e-f473-4a18-b5b8-175719b4beb6)
![shows "Enum" for enum type](https://github.com/user-attachments/assets/a4d548c4-8c21-4404-8957-d8fc4079f14c)
![shows "Struct member 'name'" for substructs](https://github.com/user-attachments/assets/20a7d3fc-7363-4775-b3d9-9284b801f579)
