### PR TITLE
Fix diagnostics publishing for LSP clients

### DIFF
--- a/server/internal/lsp/server/Initialize.go
+++ b/server/internal/lsp/server/Initialize.go
@@ -57,7 +57,8 @@ func (s *Server) Initialize(serverName string, serverVersion string, capabilitie
 		s.RunDiagnostics(s.state, context.Notify, false)
 	}
 
-	if params.Capabilities.TextDocument.PublishDiagnostics.RelatedInformation == nil || *params.Capabilities.TextDocument.PublishDiagnostics.RelatedInformation == false {
+	// Disable diagnostics only if the client does not support publishDiagnostics at all.
+	if params.Capabilities.TextDocument == nil || params.Capabilities.TextDocument.PublishDiagnostics == nil {
 		s.options.Diagnostics.Enabled = false
 	}
 


### PR DESCRIPTION
-  **What/Why?**
	- Publish diagnostics even when `c3c` exits 0 but emits `> LSP...` Lines
	- Parse both errors and warnings; safer capability check (disable only when  `publishDiagnostics`  is missing).
- **Testing:** "Not run (manual environment)"